### PR TITLE
Fixes #1 : Open Data Browse Dialog on Right Side of Main Window

### DIFF
--- a/TelAvivMuni-Exercise/Controls/DataBrowserDialog.xaml
+++ b/TelAvivMuni-Exercise/Controls/DataBrowserDialog.xaml
@@ -7,7 +7,7 @@
         Height="400"
         ResizeMode="CanResize"
         ShowInTaskbar="False"
-        WindowStartupLocation="CenterOwner"
+        WindowStartupLocation="Manual"
         Background="White"
         PreviewKeyDown="Window_PreviewKeyDown">
 

--- a/TelAvivMuni-Exercise/Services/DialogService.cs
+++ b/TelAvivMuni-Exercise/Services/DialogService.cs
@@ -19,12 +19,17 @@ namespace TelAvivMuni_Exercise.Services
 
             var viewModel = new DataBrowserDialogViewModel(items, currentSelection, columns);
 
+            var mainWindow = Application.Current.MainWindow;
             var dialog = new DataBrowserDialog
             {
                 DataContext = viewModel,
                 Title = title,
-                Owner = Application.Current.MainWindow
+                Owner = mainWindow
             };
+
+            // Position dialog to the right of the main window
+            dialog.Left = mainWindow.Left + mainWindow.ActualWidth;
+            dialog.Top = mainWindow.Top;
 
             if (dialog.ShowDialog() == true)
             {


### PR DESCRIPTION
### Feature Request

Please update the application so that when opening the data browse dialog, it appears on the **right side** of the main window.

#### Acceptance Criteria
- Opening the data browse dialog should position it docked or fixed on the right edge of the main window.
- The dialog should not cover existing content or essential controls.
- Behavior should be consistent regardless of window resizing.

#### Additional Context
This improvement will enhance usability and accessibility within the application interface.