### PR TITLE
Fixes #17 : Begin of using MS IoC implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ TelAvivMuni-Exercise/
 │   ├── UnitOfWork.cs              # Unit of Work implementation
 │   ├── FileDataStore.cs           # File-based data store
 │   ├── JsonSerializer.cs          # JSON serialization implementation
-│   └── OperationResult.cs         # Operation result with error messages
+│   ├── OperationResult.cs         # Operation result with error messages
+│   └── ViewModelLocator.cs        # DI-based ViewModel resolution for XAML
 ├── Models/
 │   ├── Product.cs                 # Product data model
 │   └── BrowserColumn.cs           # Column configuration model

--- a/TelAvivMuni-Exercise.Tests/Infrastructure/UnitOfWorkTests.cs
+++ b/TelAvivMuni-Exercise.Tests/Infrastructure/UnitOfWorkTests.cs
@@ -25,11 +25,13 @@ public class UnitOfWorkTests : IDisposable
         }
     }
 
+    private UnitOfWork CreateUnitOfWork() => new UnitOfWork(new ProductRepository() as IRepository<Product>);
+
     [Fact]
     public void Products_ReturnsRepository()
     {
         // Arrange
-        using var unitOfWork = new UnitOfWork();
+        using var unitOfWork = CreateUnitOfWork();
 
         // Act
         var products = unitOfWork.Products;
@@ -43,7 +45,7 @@ public class UnitOfWorkTests : IDisposable
     public async Task SaveChangesAsync_ReturnsCount()
     {
         // Arrange
-        using var unitOfWork = new UnitOfWork();
+        using var unitOfWork = CreateUnitOfWork();
 
         // Load and save without changes
         await unitOfWork.Products.GetAllAsync();
@@ -59,7 +61,7 @@ public class UnitOfWorkTests : IDisposable
     public void Dispose_CanBeCalledMultipleTimes()
     {
         // Arrange
-        var unitOfWork = new UnitOfWork();
+        var unitOfWork = CreateUnitOfWork();
 
         // Act & Assert - should not throw
         unitOfWork.Dispose();
@@ -71,7 +73,7 @@ public class UnitOfWorkTests : IDisposable
     public void Products_SameInstance_MultipleCalls()
     {
         // Arrange
-        using var unitOfWork = new UnitOfWork();
+        using var unitOfWork = CreateUnitOfWork();
 
         // Act
         var products1 = unitOfWork.Products;
@@ -85,7 +87,7 @@ public class UnitOfWorkTests : IDisposable
     public async Task IntegrationTest_AddAndSave()
     {
         // Arrange
-        using var unitOfWork = new UnitOfWork();
+        using var unitOfWork = CreateUnitOfWork();
         var product = new Product
         {
             Id = 0,

--- a/TelAvivMuni-Exercise/App.xaml
+++ b/TelAvivMuni-Exercise/App.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:TelAvivMuni_Exercise"
              xmlns:services="clr-namespace:TelAvivMuni_Exercise.Services"
+             xmlns:localInfra="clr-namespace:TelAvivMuni_Exercise.Infrastructure"
              StartupUri="MainWindow.xaml">
   <Application.Resources>
     <ResourceDictionary>
@@ -11,6 +12,7 @@
         <ResourceDictionary Source="/Themes/Generic.xaml" />
       </ResourceDictionary.MergedDictionaries>
       <services:DialogService x:Key="DialogService" />
+      <localInfra:ViewModelLocator x:Key="Locator" />
     </ResourceDictionary>
   </Application.Resources>
 </Application>

--- a/TelAvivMuni-Exercise/App.xaml.cs
+++ b/TelAvivMuni-Exercise/App.xaml.cs
@@ -1,6 +1,10 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Windows;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using TelAvivMuni_Exercise.Infrastructure;
+using TelAvivMuni_Exercise.Models;
+using TelAvivMuni_Exercise.ViewModels;
 
 namespace TelAvivMuni_Exercise;
 
@@ -10,13 +14,45 @@ namespace TelAvivMuni_Exercise;
 [ExcludeFromCodeCoverage]
 public partial class App : Application
 {
-    private static IUnitOfWork? _unitOfWork;
+    private readonly IHost _host;
 
-    public static IUnitOfWork UnitOfWork => _unitOfWork ??= new UnitOfWork();
-
-    protected override void OnExit(ExitEventArgs e)
+    public App()
     {
-        _unitOfWork?.Dispose();
+        _host = Host.CreateDefaultBuilder()
+            .ConfigureServices((context, services) =>
+            {
+                ConfigureServices(services);
+            })
+            .Build();
+
+        // Initialize the locator
+        ViewModelLocator.Initialize(_host.Services);
+    }
+
+    private static void ConfigureServices(IServiceCollection services)
+    {
+        // Register infrastructure
+        services.AddSingleton<IRepository<Product>, ProductRepository>();
+        services.AddSingleton<IUnitOfWork, UnitOfWork>();
+
+        // Register ViewModels
+        services.AddTransient<MainWindowViewModel>();
+
+        // Register the locator as a resource
+        services.AddSingleton<ViewModelLocator>();
+    }
+
+    protected override async void OnStartup(StartupEventArgs e)
+    {
+        await _host.StartAsync();
+        base.OnStartup(e);
+        // StartupUri in App.xaml handles MainWindow creation
+    }
+
+    protected override async void OnExit(ExitEventArgs e)
+    {
+        await _host.StopAsync();
+        _host.Dispose();
         base.OnExit(e);
     }
 }

--- a/TelAvivMuni-Exercise/Infrastructure/IRepositoryT.cs
+++ b/TelAvivMuni-Exercise/Infrastructure/IRepositoryT.cs
@@ -11,5 +11,11 @@ namespace TelAvivMuni_Exercise.Infrastructure
         Task<OperationResult> AddAsync(TEntity entity);
         Task<OperationResult> UpdateAsync(TEntity entity);
         Task<OperationResult> DeleteAsync(TEntity entity);
+
+        /// <summary>
+        /// Saves all changes to the data store.
+        /// </summary>
+        /// <returns>The number of entities saved.</returns>
+        Task<int> SaveAsync();
     }
 }

--- a/TelAvivMuni-Exercise/Infrastructure/ProductRepository.cs
+++ b/TelAvivMuni-Exercise/Infrastructure/ProductRepository.cs
@@ -113,11 +113,8 @@ namespace TelAvivMuni_Exercise.Infrastructure
                 : OperationResult.Fail($"Product with Id {entity.Id} was not found.");
         }
 
-        /// <summary>
-        /// Saves all changes to the data store.
-        /// </summary>
-        /// <returns>The number of entities saved.</returns>
-        internal async Task<int> SaveAsync()
+        /// <inheritdoc />
+        public async Task<int> SaveAsync()
         {
             return await _dataStore.SaveAsync(_entities);
         }
@@ -127,7 +124,7 @@ namespace TelAvivMuni_Exercise.Infrastructure
         /// </summary>
         public async Task ReloadAsync()
         {
-            _entities = new List<Product>(await _dataStore.LoadAsync());
+            _entities = [.. await _dataStore.LoadAsync()];
             _isLoaded = true;
         }
 

--- a/TelAvivMuni-Exercise/Infrastructure/UnitOfWork.cs
+++ b/TelAvivMuni-Exercise/Infrastructure/UnitOfWork.cs
@@ -9,22 +9,14 @@ namespace TelAvivMuni_Exercise.Infrastructure
     /// </summary>
     public class UnitOfWork : IUnitOfWork
     {
-        private readonly ProductRepository _productRepository;
+        private readonly IRepository<Product> _productRepository;
         private bool _disposed;
 
         /// <summary>
-        /// Initializes a new instance of UnitOfWork with a default ProductRepository.
-        /// </summary>
-        public UnitOfWork()
-            : this(new ProductRepository())
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of UnitOfWork with a custom repository.
+        /// Initializes a new instance of UnitOfWork with the specified repository.
         /// </summary>
         /// <param name="productRepository">The product repository to use.</param>
-        public UnitOfWork(ProductRepository productRepository)
+        public UnitOfWork(IRepository<Product> productRepository)
         {
             _productRepository = productRepository ?? throw new ArgumentNullException(nameof(productRepository));
         }

--- a/TelAvivMuni-Exercise/Infrastructure/ViewModelLocator.cs
+++ b/TelAvivMuni-Exercise/Infrastructure/ViewModelLocator.cs
@@ -1,0 +1,54 @@
+// TelAvivMuni-Exercise\Services\ViewModelLocator.cs
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using TelAvivMuni_Exercise.ViewModels;
+
+namespace TelAvivMuni_Exercise.Infrastructure;
+
+/// <summary>
+/// Provides ViewModel resolution for Views without direct type coupling.
+/// </summary>
+public class ViewModelLocator
+{
+    private static IServiceProvider _serviceProvider;
+
+    /// <summary>
+    /// Initializes the locator with the application's service provider.
+    /// Must be called during application startup before resolving ViewModels.
+    /// </summary>
+    /// <param name="serviceProvider">The dependency injection service provider.</param>
+    public static void Initialize(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+
+    /// <summary>
+    /// Resolves a ViewModel instance by its type.
+    /// </summary>
+    /// <param name="viewModelType">The type of ViewModel to resolve.</param>
+    /// <returns>The resolved ViewModel instance.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the locator is not initialized.</exception>
+    public static object Resolve(Type viewModelType)
+    {
+        return _serviceProvider.GetRequiredService(viewModelType)
+            ?? throw new InvalidOperationException("ViewModelLocator not initialized");
+    }
+
+    /// <summary>
+    /// Resolves a ViewModel instance by its generic type parameter.
+    /// </summary>
+    /// <typeparam name="TViewModel">The type of ViewModel to resolve.</typeparam>
+    /// <returns>The resolved ViewModel instance.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the locator is not initialized.</exception>
+    public static TViewModel Resolve<TViewModel>() where TViewModel : class
+    {
+        return _serviceProvider.GetRequiredService<TViewModel>()
+            ?? throw new InvalidOperationException("ViewModelLocator not initialized");
+    }
+
+    /// <summary>
+    /// Gets the MainWindowViewModel instance for XAML data binding.
+    /// </summary>
+    public MainWindowViewModel MainWindow
+        => Resolve<MainWindowViewModel>();
+}

--- a/TelAvivMuni-Exercise/MainWindow.xaml
+++ b/TelAvivMuni-Exercise/MainWindow.xaml
@@ -6,10 +6,8 @@
         xmlns:vm="clr-namespace:TelAvivMuni_Exercise.ViewModels"
         Title="Tel-Aviv Muni - Exercise"
         Width="520"
-        Height="430">
-  <Window.DataContext>
-    <vm:MainWindowViewModel />
-  </Window.DataContext>
+        Height="430"
+        DataContext="{Binding MainWindow, Source={StaticResource Locator}}">
   <Grid>
     <StackPanel Margin="20">
       <!--  Header  -->

--- a/TelAvivMuni-Exercise/MainWindow.xaml.cs
+++ b/TelAvivMuni-Exercise/MainWindow.xaml.cs
@@ -9,5 +9,6 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
+        // No ViewModel reference here - it's bound in XAML
     }
 }

--- a/TelAvivMuni-Exercise/Services/DialogService.cs
+++ b/TelAvivMuni-Exercise/Services/DialogService.cs
@@ -8,9 +8,20 @@ using TelAvivMuni_Exercise.ViewModels;
 
 namespace TelAvivMuni_Exercise.Services
 {
+    /// <summary>
+    /// Provides dialog display services for the application.
+    /// </summary>
     [ExcludeFromCodeCoverage]
     public class DialogService : IDialogService
     {
+        /// <summary>
+        /// Displays a modal browse dialog for selecting an item from a collection.
+        /// </summary>
+        /// <param name="items">The collection of items to display in the dialog.</param>
+        /// <param name="title">The dialog window title.</param>
+        /// <param name="currentSelection">The currently selected item, if any.</param>
+        /// <param name="columns">Optional column configuration for the data grid.</param>
+        /// <returns>The selected item if confirmed; otherwise, the original selection.</returns>
         public object? ShowBrowseDialog(IEnumerable items, string title, object? currentSelection, ObservableCollection<BrowserColumn>? columns = null)
         {
             if (items == null)

--- a/TelAvivMuni-Exercise/TelAvivMuni-Exercise.csproj
+++ b/TelAvivMuni-Exercise/TelAvivMuni-Exercise.csproj
@@ -15,6 +15,9 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.135" />
   </ItemGroup>
 

--- a/TelAvivMuni-Exercise/ViewModels/DataBrowserDialogViewModel.cs
+++ b/TelAvivMuni-Exercise/ViewModels/DataBrowserDialogViewModel.cs
@@ -151,6 +151,11 @@ namespace TelAvivMuni_Exercise.ViewModels
             IsLoading = false;
         }
 
+        /// <summary>
+        /// Filters items based on the current search text by checking all property values.
+        /// </summary>
+        /// <param name="item">The item to evaluate for filtering.</param>
+        /// <returns>True if the item matches the search criteria or search is empty; otherwise, false.</returns>
         private bool FilterItems(object item)
         {
             if (string.IsNullOrWhiteSpace(SearchText))
@@ -169,6 +174,9 @@ namespace TelAvivMuni_Exercise.ViewModels
             return false;
         }
 
+        /// <summary>
+        /// Handles the OK command by setting the dialog result to true.
+        /// </summary>
         private void OnOk()
         {
             DialogResult = true;
@@ -189,11 +197,17 @@ namespace TelAvivMuni_Exercise.ViewModels
             return _filteredItems.Cast<object>().Contains(SelectedItem);
         }
 
+        /// <summary>
+        /// Handles the Cancel command by setting the dialog result to false.
+        /// </summary>
         private void OnCancel()
         {
             DialogResult = false;
         }
 
+        /// <summary>
+        /// Clears the search text, restoring all items to the filtered view.
+        /// </summary>
         private void OnClearSearch()
         {
             SearchText = string.Empty;

--- a/TelAvivMuni-Exercise/ViewModels/MainWindowViewModel.cs
+++ b/TelAvivMuni-Exercise/ViewModels/MainWindowViewModel.cs
@@ -4,11 +4,16 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.DependencyInjection;
 using TelAvivMuni_Exercise.Infrastructure;
 using TelAvivMuni_Exercise.Models;
 
 namespace TelAvivMuni_Exercise.ViewModels
 {
+    /// <summary>
+    /// ViewModel for the main application window, managing product data operations
+    /// through the Unit of Work pattern.
+    /// </summary>
     public partial class MainWindowViewModel : ObservableObject
     {
         private readonly IUnitOfWork _unitOfWork;
@@ -42,19 +47,20 @@ namespace TelAvivMuni_Exercise.ViewModels
         }
 
         /// <summary>
-        /// Runtime constructor used by XAML. Requires WPF Application context.
+        /// Initializes a new instance of the <see cref="MainWindowViewModel"/> class.
         /// </summary>
-        [ExcludeFromCodeCoverage]
-        public MainWindowViewModel() : this(App.UnitOfWork)
-        {
-        }
-
+        /// <param name="unitOfWork">The unit of work for data persistence operations.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="unitOfWork"/> is null.</exception>
         public MainWindowViewModel(IUnitOfWork unitOfWork)
         {
             _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
             _ = LoadProductsAsync();
         }
 
+        /// <summary>
+        /// Loads all products from the repository into the <see cref="Products"/> collection.
+        /// </summary>
+        /// <returns>A task representing the asynchronous load operation.</returns>
         private async Task LoadProductsAsync()
         {
             try
@@ -68,6 +74,11 @@ namespace TelAvivMuni_Exercise.ViewModels
             }
         }
 
+        /// <summary>
+        /// Adds a new product to the repository and saves changes.
+        /// </summary>
+        /// <param name="product">The product to add.</param>
+        /// <returns>An <see cref="OperationResult"/> indicating success or failure.</returns>
         [RelayCommand]
         private async Task<OperationResult> AddProductAsync(Product product)
         {
@@ -83,6 +94,11 @@ namespace TelAvivMuni_Exercise.ViewModels
             return result;
         }
 
+        /// <summary>
+        /// Updates an existing product in the repository and saves changes.
+        /// </summary>
+        /// <param name="product">The product with updated values.</param>
+        /// <returns>An <see cref="OperationResult"/> indicating success or failure.</returns>
         [RelayCommand]
         private async Task<OperationResult> UpdateProductAsync(Product product)
         {
@@ -97,6 +113,11 @@ namespace TelAvivMuni_Exercise.ViewModels
             return result;
         }
 
+        /// <summary>
+        /// Deletes a product from the repository and saves changes.
+        /// </summary>
+        /// <param name="product">The product to delete.</param>
+        /// <returns>An <see cref="OperationResult"/> indicating success or failure.</returns>
         [RelayCommand]
         private async Task<OperationResult> DeleteProductAsync(Product product)
         {
@@ -112,6 +133,10 @@ namespace TelAvivMuni_Exercise.ViewModels
             return result;
         }
 
+        /// <summary>
+        /// Persists all pending changes to the underlying data store.
+        /// </summary>
+        /// <returns>An <see cref="OperationResult"/> indicating success or failure.</returns>
         [RelayCommand]
         private async Task<OperationResult> SaveChangesAsync()
         {


### PR DESCRIPTION
Fix DI container configuration for ViewModelLocator pattern

- Add missing ViewModels namespace import to ViewModelLocator
- Change UnitOfWork constructor from internal to public for DI resolution
- Wire up MainWindow.DataContext via ViewModelLocator binding
- Remove obsolete parameterless constructor from MainWindowViewModel
- Update README to document ViewModelLocator infrastructure component