### PR TITLE
Fix MC3074: restore assembly= qualifier on xmlns:local in MainWindow.…

### DIFF
--- a/TelAvivMuni-Exercise.Presentation/Views/MainWindow.xaml
+++ b/TelAvivMuni-Exercise.Presentation/Views/MainWindow.xaml
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:pres="http://telaviv-muni-exe/presentation"
         xmlns:controls="http://telaviv-muni-exe/controls"
-        xmlns:local="clr-namespace:TelAvivMuni_Exercise.Domain"
+        xmlns:local="clr-namespace:TelAvivMuni_Exercise.Domain;assembly=TelAvivMuni-Exercise.Domain"
         Title="Tel-Aviv Muni - Exercise"
         Width="520"
         Height="455"


### PR DESCRIPTION
…xaml

After MainWindow.xaml was moved to the Presentation project, the cross-assembly clr-namespace reference to TelAvivMuni_Exercise.Domain was missing the required assembly= qualifier. Without it the XAML compiler searches only the current (Presentation) assembly and cannot find BrowserColumn, emitting MC3074.

Restores: xmlns:local="clr-namespace:TelAvivMuni_Exercise.Domain;assembly=TelAvivMuni-Exercise.Domain"

Build: 0 errors, 0 warnings. 163 tests pass.