### PR TITLE
Sync single-selection DataGrid mode to bound collection and add multi-select OK command test

### DIFF
--- a/TelAvivMuni-Exercise.Controls/Behaviors/DataGridMultiSelectBehavior.cs
+++ b/TelAvivMuni-Exercise.Controls/Behaviors/DataGridMultiSelectBehavior.cs
@@ -67,12 +67,19 @@ public static class DataGridMultiSelectBehavior
 	private static void OnDataGridSelectionChanged(DataGrid dataGrid, ObservableCollection<object> selectedItems, SyncState state)
 	{
 		if (state.IsSyncing) return;
-		if (dataGrid.SelectionMode == DataGridSelectionMode.Single) return;
 
 		state.IsSyncing = true;
 		try
 		{
 			selectedItems.Clear();
+
+			if (dataGrid.SelectionMode == DataGridSelectionMode.Single)
+			{
+				if (dataGrid.SelectedItem != null)
+					selectedItems.Add(dataGrid.SelectedItem);
+				return;
+			}
+
 			foreach (var item in dataGrid.SelectedItems)
 				selectedItems.Add(item);
 		}
@@ -89,11 +96,16 @@ public static class DataGridMultiSelectBehavior
 	private static void OnCollectionChanged(DataGrid dataGrid, ObservableCollection<object> selectedItems, SyncState state)
 	{
 		if (state.IsSyncing) return;
-		if (dataGrid.SelectionMode == DataGridSelectionMode.Single) return;
 
 		state.IsSyncing = true;
 		try
 		{
+			if (dataGrid.SelectionMode == DataGridSelectionMode.Single)
+			{
+				dataGrid.SelectedItem = selectedItems.FirstOrDefault();
+				return;
+			}
+
 			dataGrid.SelectedItems.Clear();
 			foreach (var item in selectedItems)
 				dataGrid.SelectedItems.Add(item);

--- a/TelAvivMuni-Exercise.Tests/Presentation/DataBrowserDialogViewModelTests.cs
+++ b/TelAvivMuni-Exercise.Tests/Presentation/DataBrowserDialogViewModelTests.cs
@@ -459,6 +459,19 @@ public class DataBrowserDialogViewModelTests
 		}
 
 		[Fact]
+		public void OkCommand_CanExecute_TrueInMultiSelectWhenSelectedItemsCollectionHasItems()
+		{
+			// Arrange
+			var viewModel = new DataBrowserDialogViewModel(CreateTestProducts(), null, columns: null, allowMultipleSelection: true);
+			viewModel.Initialize();
+			viewModel.SelectedItems.Add(viewModel.FilteredItems.Cast<object>().First());
+
+			// Assert
+			Assert.True(viewModel.OkCommand.CanExecute(null));
+		}
+
+
+		[Fact]
 		public void CancelCommand_SetsDialogResultFalse()
 		{
 			// Arrange


### PR DESCRIPTION
### Motivation

- Ensure selection synchronization works for both `DataGridSelectionMode.Single` and multi-select modes so the bound `ObservableCollection<object>` and the `DataGrid` stay in sync.
- Add coverage for multi-selection behavior in the view model `OkCommand` logic.

### Description

- Update `DataGridMultiSelectBehavior` to remove the early-return for single-selection and explicitly handle `SelectionMode.Single` in `OnDataGridSelectionChanged` by clearing the collection and adding the `SelectedItem` when present.
- Update `DataGridMultiSelectBehavior` to handle `SelectionMode.Single` in `OnCollectionChanged` by setting `dataGrid.SelectedItem` to the first item in the bound collection instead of returning early.
- Keep the existing multi-selection paths intact by populating `SelectedItems`/collection when in multi-select mode.
- Add a unit test `OkCommand_CanExecute_TrueInMultiSelectWhenSelectedItemsCollectionHasItems` to `DataBrowserDialogViewModelTests` to assert `OkCommand` is enabled when `SelectedItems` contains items in multi-select mode.

### Testing

- Ran the unit test suite with `dotnet test` for the project, including `DataBrowserDialogViewModelTests`; the new test `OkCommand_CanExecute_TrueInMultiSelectWhenSelectedItemsCollectionHasItems` passed.
- All existing automated tests in the `TelAvivMuni-Exercise.Tests` project passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac8628025c8324a67dff98685552df)