### PR TITLE
Reorganize docs: update README and add ARCHITECTURE, SETUP_GUIDE, README_USER_SHORT

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,308 @@
+# Architecture
+
+## Overview
+
+The solution follows a clean layered architecture with 23 projects. Dependencies flow strictly downward: Persistence → Domain → Core → Presentation → Composition Root. Provider-specific assemblies (database and file-format plugins) are discovered at runtime via assembly scanning so the composition root has no compile-time dependency on individual providers.
+
+## Layer Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  Composition Root (TelAvivMuni-Exercise WPF)                         │
+│  DI wiring, App.xaml, StorageRegistrationExtensions                 │
+└──────────────────────────┬──────────────────────────────────────────┘
+                           │
+         ┌─────────────────┴──────────────────┐
+         ▼                                    ▼
+┌─────────────────┐                ┌───────────────────────┐
+│  Presentation   │                │       Themes          │
+│  Controls       │                │  Blue, Emerald,       │
+│  Presentation   │                │  GruvboxDark, AyuDark │
+└────────┬────────┘                └───────────────────────┘
+         │
+         ▼
+┌─────────────────────────────────────────────────────────────┐
+│  Business Logic                                              │
+│  Core / Core.Contracts / Domain / Infrastructure            │
+└──────────────────────────┬──────────────────────────────────┘
+                           │
+         ┌─────────────────┴──────────────────┐
+         ▼                                    ▼
+┌─────────────────┐               ┌──────────────────────────────┐
+│  Persistence    │               │  Provider Plugins            │
+│  (abstractions) │               │  (runtime-discovered DLLs)   │
+│  FileBase       │               │  SqlServer, Sqlite,          │
+│  Database       │               │  PostgreSQL, MySql,          │
+└─────────────────┘               │  Xml, Csv                    │
+                                  └──────────────────────────────┘
+```
+
+## Project Dependency Graph
+
+```
+TelAvivMuni-Exercise.Persistence  (no project dependencies)
+    └── Contains: IEntity, IDataStore<T>, ISerializer<T>, ILocatableDataStore<T>
+
+TelAvivMuni-Exercise.Persistence.FileBase
+    └── → TelAvivMuni-Exercise.Persistence
+    └── Contains: FileDataStore<T>, IFileProviderRegistrar
+
+TelAvivMuni-Exercise.Persistence.FileBase.Json
+    └── → TelAvivMuni-Exercise.Persistence.FileBase
+    └── Contains: JsonSerializer<T>, JsonFileProviderRegistrar
+
+TelAvivMuni-Exercise.Persistence.FileBase.Xml
+    └── → TelAvivMuni-Exercise.Persistence.FileBase
+    └── Contains: XmlSerializer<T>, XmlFileProviderRegistrar
+
+TelAvivMuni-Exercise.Persistence.FileBase.Csv
+    └── → TelAvivMuni-Exercise.Persistence.FileBase
+    └── Contains: CsvSerializer<T>, CsvFileProviderRegistrar
+
+TelAvivMuni-Exercise.Persistence.Database
+    └── → TelAvivMuni-Exercise.Persistence
+    └── Contains: DbDataStore<TEntity, TContext>, IDbContextRegistrar, IDbProviderRegistrar, IAppDbContextFactory
+
+TelAvivMuni-Exercise.Persistence.Database.SqlServer
+    └── → TelAvivMuni-Exercise.Persistence.Database
+    └── Contains: SqlServerProviderRegistrar  [runtime plugin]
+
+TelAvivMuni-Exercise.Persistence.Database.Sqlite
+    └── → TelAvivMuni-Exercise.Persistence.Database
+    └── Contains: SqliteProviderRegistrar  [runtime plugin]
+
+TelAvivMuni-Exercise.Persistence.Database.PostgreSQL
+    └── → TelAvivMuni-Exercise.Persistence.Database
+    └── Contains: PostgreSQLProviderRegistrar  [runtime plugin]
+
+TelAvivMuni-Exercise.Persistence.Database.MySql
+    └── → TelAvivMuni-Exercise.Persistence.Database
+    └── Contains: MySqlProviderRegistrar  [runtime plugin]
+
+TelAvivMuni-Exercise.Infrastructure  (no project dependencies)
+    └── Contains: IDeferredInitialization
+
+TelAvivMuni-Exercise.Domain
+    └── → TelAvivMuni-Exercise.Persistence
+    └── Contains: Product, BrowserColumn, OperationResult
+
+TelAvivMuni-Exercise.Core.Contracts
+    ├── → TelAvivMuni-Exercise.Domain
+    └── → TelAvivMuni-Exercise.Persistence
+    └── Contains: IRepository<T>, IUnitOfWork, IDialogService, IColumnConfiguration, IMultiSelectViewModel
+
+TelAvivMuni-Exercise.Core
+    ├── → TelAvivMuni-Exercise.Core.Contracts
+    ├── → TelAvivMuni-Exercise.Persistence
+    ├── → TelAvivMuni-Exercise.Persistence.Database
+    └── → TelAvivMuni-Exercise.Domain
+    └── Contains: AppDbContext, ProductRepository, UnitOfWork, AppDbContextRegistrar, CoreAssembly
+
+TelAvivMuni-Exercise.Themes  (no project dependencies)
+    └── Contains: Shared.xaml (neutral brush defaults, shared vector icons)
+
+TelAvivMuni-Exercise.Themes.Blue
+    └── → TelAvivMuni-Exercise.Themes
+    └── Contains: Blue.xaml, Blue.Colors.xaml, Blue.Styles.xaml
+
+TelAvivMuni-Exercise.Themes.Emerald
+    └── → TelAvivMuni-Exercise.Themes
+    └── Contains: Emerald.xaml, Emerald.Colors.xaml, Emerald.Styles.xaml
+
+TelAvivMuni-Exercise.Themes.Zed.GruvboxDark
+    ├── → TelAvivMuni-Exercise.Themes
+    └── → TelAvivMuni-Exercise.Controls
+    └── Contains: GruvboxDark.xaml, GruvboxDark.Colors.xaml, GruvboxDark.Styles.xaml
+
+TelAvivMuni-Exercise.Themes.Zed.AyuDark
+    ├── → TelAvivMuni-Exercise.Themes
+    └── → TelAvivMuni-Exercise.Controls
+    └── Contains: AyuDark.xaml, AyuDark.Colors.xaml, AyuDark.Styles.xaml
+
+TelAvivMuni-Exercise.Controls
+    ├── → TelAvivMuni-Exercise.Core.Contracts
+    ├── → TelAvivMuni-Exercise.Persistence
+    ├── → TelAvivMuni-Exercise.Domain
+    └── → TelAvivMuni-Exercise.Themes
+    └── Contains: DataBrowserBox, DataBrowserDialog, Behaviors
+
+TelAvivMuni-Exercise.Presentation
+    ├── → TelAvivMuni-Exercise.Core.Contracts
+    ├── → TelAvivMuni-Exercise.Persistence
+    ├── → TelAvivMuni-Exercise.Controls
+    └── → TelAvivMuni-Exercise.Domain
+    └── Contains: ViewModels, DialogService, ViewModelLocator, MainWindow
+
+TelAvivMuni-Exercise (WPF — composition root)
+    ├── → TelAvivMuni-Exercise.Presentation
+    ├── → TelAvivMuni-Exercise.Controls
+    ├── → TelAvivMuni-Exercise.Core
+    ├── → TelAvivMuni-Exercise.Core.Contracts
+    ├── → TelAvivMuni-Exercise.Infrastructure
+    ├── → TelAvivMuni-Exercise.Domain
+    ├── → TelAvivMuni-Exercise.Persistence
+    ├── → TelAvivMuni-Exercise.Persistence.Database
+    ├── → TelAvivMuni-Exercise.Persistence.FileBase
+    ├── → TelAvivMuni-Exercise.Persistence.Database.SqlServer  [plugin]
+    ├── → TelAvivMuni-Exercise.Persistence.Database.Sqlite     [plugin]
+    ├── → TelAvivMuni-Exercise.Persistence.Database.PostgreSQL [plugin]
+    ├── → TelAvivMuni-Exercise.Persistence.Database.MySql      [plugin]
+    ├── → TelAvivMuni-Exercise.Persistence.FileBase.Json       [plugin]
+    ├── → TelAvivMuni-Exercise.Persistence.FileBase.Xml        [plugin]
+    ├── → TelAvivMuni-Exercise.Persistence.FileBase.Csv        [plugin]
+    ├── → TelAvivMuni-Exercise.Themes.Blue
+    ├── → TelAvivMuni-Exercise.Themes.Emerald
+    ├── → TelAvivMuni-Exercise.Themes.Zed.GruvboxDark
+    └── → TelAvivMuni-Exercise.Themes.Zed.AyuDark
+
+TelAvivMuni-Exercise.Tests
+    ├── → TelAvivMuni-Exercise (WPF)
+    ├── → TelAvivMuni-Exercise.Presentation
+    ├── → TelAvivMuni-Exercise.Controls
+    ├── → TelAvivMuni-Exercise.Core
+    ├── → TelAvivMuni-Exercise.Core.Contracts
+    ├── → TelAvivMuni-Exercise.Persistence
+    └── → TelAvivMuni-Exercise.Domain
+```
+
+## Persistence Layer
+
+The persistence layer uses the **Strategy pattern** with runtime-discovered provider plugins.
+
+### Layered abstraction
+
+```
+ProductRepository (Core)
+    └── IDataStore<Product> (Persistence)
+            ├── FileDataStore<Product> (Persistence.FileBase)
+            │       └── ISerializer<Product>
+            │               ├── JsonSerializer<Product>  (Persistence.FileBase.Json)
+            │               ├── XmlSerializer<Product>   (Persistence.FileBase.Xml)
+            │               └── CsvSerializer<Product>   (Persistence.FileBase.Csv)
+            │
+            └── DbDataStore<Product, AppDbContext>  (Persistence.Database)
+                    └── IAppDbContextFactory<AppDbContext> (Core)
+                            └── Provider registered by:
+                                ├── SqlServerProviderRegistrar
+                                ├── SqliteProviderRegistrar
+                                ├── PostgreSQLProviderRegistrar
+                                └── MySqlProviderRegistrar
+```
+
+### Provider plugin discovery
+
+`StorageRegistrationExtensions` scans loaded assemblies at runtime for `IFileProviderRegistrar` and `IDbProviderRegistrar` implementations. The selected provider (from `appsettings.json`) is instantiated and calls its `Register(IServiceCollection)` method. This means:
+- Adding a new provider requires dropping a DLL in the bin directory and updating `appsettings.json`.
+- No recompilation of the composition root is needed.
+
+## Repository and Unit of Work Patterns
+
+```csharp
+public interface IRepository<TEntity> where TEntity : class
+{
+    IEnumerable<TEntity> Entities { get; }
+    Task<TEntity[]> GetAllAsync();
+    Task<TEntity?> GetByIdAsync(int id);
+    Task<OperationResult> AddAsync(TEntity entity);
+    Task<OperationResult> UpdateAsync(TEntity entity);
+    Task<OperationResult> DeleteAsync(TEntity entity);
+}
+
+public interface IUnitOfWork : IDisposable
+{
+    IRepository<Product> Products { get; }
+    Task<int> SaveChangesAsync();
+}
+```
+
+`OperationResult` provides a consistent return type for CRUD operations:
+```csharp
+var result = await repository.AddAsync(product);
+if (!result.Success)
+    Console.WriteLine(result.ErrorMessage); // "A product with Id 1 already exists."
+```
+
+## MVVM and Attached Behaviors
+
+The application is a **pure MVVM** implementation — no UI logic in code-behind. Keyboard handling and DataGrid interactions are implemented as reusable attached behaviors:
+
+| Behavior | Description |
+|----------|-------------|
+| `AutoFocusSearchBehavior` | Focuses the search box when the user starts typing anywhere in the dialog |
+| `DataGridEnterBehavior` | Fires a command when Enter is pressed in the DataGrid |
+| `DataGridScrollIntoViewBehavior` | Scrolls the DataGrid to show the selected item |
+| `DataGridMultiSelectBehavior` | Synchronizes DataGrid multi-selection with the ViewModel |
+| `DialogCloseBehavior` | Closes the window when `ViewModel.DialogResult` changes |
+| `EscapeClearBehavior` | Clears a TextBox when Escape is pressed |
+
+## View-First Initialization (Deferred Loading)
+
+The browse dialog uses a **View-First** pattern to display a loading overlay while data loads asynchronously:
+
+1. The window is shown immediately with a semi-transparent "Loading..." overlay.
+2. `ContentRendered` triggers `Initialize()` via XAML `CallMethodAction` (no code-behind).
+3. The ViewModel implements `IDeferredInitialization` and stores pending items/selection until called.
+4. Once initialized, the overlay is hidden and the DataGrid is populated.
+
+`IColumnConfiguration` is a separate interface consumed by `DataBrowserDialog` to receive custom column definitions without a circular project reference.
+
+## Custom Control vs UserControl
+
+`DataBrowserBox` is a **Custom Control** (not a UserControl) for the following reasons:
+- Template-based: consumers can completely replace the visual tree via `ControlTemplate`.
+- Dependency properties enable WPF-style binding, animations, and style triggers.
+- Follows WPF lookup conventions (`Generic.xaml` default template).
+
+## Theme Architecture
+
+Each theme is a standalone WPF class library with a three-file structure:
+
+```
+Theme.xaml          ← Entry point; merges Shared.xaml + Theme.Styles.xaml
+Theme.Colors.xaml   ← Brush definitions (color palette)
+Theme.Styles.xaml   ← Control styles (Button, DataGrid, DataBrowserBox override)
+```
+
+`Shared.xaml` (base `Themes` project) defines neutral fallback brushes and shared vector icons used by all themes.
+
+All resource lookups use `StaticResource` (not `DynamicResource`) for faster XAML parsing and no runtime re-resolution overhead.
+
+Dark themes (`GruvboxDark`, `AyuDark`) include an implicit `Style TargetType="DataBrowserBox"` that overrides the default light-mode styles defined in `Generic.xaml`.
+
+## Key Design Decisions
+
+### No circular dependencies
+`IMultiSelectViewModel` lives in `Core.Contracts` so `DataBrowserDialog` (Controls) can reference it without depending on `Presentation`.
+
+### `CoreAssembly` helper
+`StorageRegistrationExtensions` uses `CoreAssembly.Reference` (a static property returning `Assembly.GetExecutingAssembly()` from the Core project) rather than a hardcoded assembly name string, ensuring correct runtime resolution regardless of rename or deployment path.
+
+### XmlnsDefinition mappings
+- `http://telaviv-muni-exe/controls` → `Controls` and `Controls.Behaviors` namespaces
+- `http://telaviv-muni-exe/presentation` → all `Presentation` namespaces
+
+These allow XAML consumers to use short namespace aliases instead of verbose `clr-namespace:...;assembly=...` declarations.
+
+### Error handling strategy
+- Collections are always initialized to empty, never `null`.
+- `OperationResult` carries descriptive error messages for user display.
+- File-loading errors (missing file, invalid JSON, IO errors) are caught and surfaced with user-friendly messages.
+- Dialog opening is guarded: a null/empty collection shows a message box instead of an empty dialog.
+
+## Version History Summary
+
+| Version | Change |
+|---------|--------|
+| v8.3 | Multi-select mode (`AllowMultipleSelection`) + 13 new tests (176 total) |
+| v8.2 | Ayu Dark theme (Zed editor palette) |
+| v8.1 | GruvboxDark theme + full dark UI theming |
+| v8.0 | Theme assemblies extracted; `DynamicResource` → `StaticResource` |
+| v7.3 | `XmlnsDefinition` for Controls assembly |
+| v7.2 | `MainWindow` moved to Presentation; pure composition root |
+| v7.1 | `CoreAssembly` helper; removed hardcoded assembly name |
+| v7.0 | Project decomposition (Domain, Controls, Presentation extracted) |
+| v6.0 | Core decoupled from EF Core; clean layering |
+| v5.0 | EF Core database support; pluggable persistence |
+| v4.0 | 163 unit tests + coverlet coverage |
+| v3.0 | Repository and Unit of Work patterns |
+| v2.0 | MVVM refactor; attached behaviors replacing code-behind |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The solution follows a clean layered architecture with 23 projects. Dependencies flow strictly downward: Persistence → Domain → Core → Presentation → Composition Root. Provider-specific assemblies (database and file-format plugins) are discovered at runtime via assembly scanning so the composition root has no compile-time dependency on individual providers.
+The solution follows a clean layered architecture with 23 projects. Dependencies flow strictly downward: Persistence → Domain → Core → Presentation → Composition Root. Provider-specific assemblies (database and file-format plugins) are discovered at runtime via assembly scanning, so the composition root has no compile-time type coupling to individual providers. In the default build, the composition root may still reference provider projects so their DLLs are deployed and available for runtime discovery.
 
 ## Layer Diagram
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TelAviv Municipality Exercise
+# TelAvivMuni-Exercise
 
 A WPF application demonstrating a reusable data browser control for selecting items from collections with search and filtering capabilities.
 
@@ -6,883 +6,88 @@ A WPF application demonstrating a reusable data browser control for selecting it
 
 This project is a home exercise created as part of an interview for the Software Developer position at Tel-Aviv Municipality. It showcases a custom WPF control (`DataBrowserBox`) that provides a modern, user-friendly interface for browsing and selecting items from data collections.
 
-## Features
+## Key Features
 
-### Custom DataBrowserBox Control
-- **Reusable WPF Custom Control** - Can be used anywhere in the application with any data type
-- **Display Member Path** - Configure which property to display in the control
-- **Two-Way Data Binding** - Full MVVM support: `SelectedItem` (single) / `SelectedItems` (multi) bindings
-- **Multi-Select Mode** - `AllowMultipleSelection` enables multi-item selection with a ×-clear button
-- **Custom Column Configuration** - Define columns with custom headers, widths, formats, and alignment
-- **Auto-Generated Columns** - Automatically generates columns from data type (default behavior)
-- **Visual Feedback** - Watermark text in italic, selected items in bold
-- **Modern UI** - Styled browse button with hover effects
-- **Selection Persistence** - Currently selected item is highlighted when dialog reopens
+- **DataBrowserBox** — Reusable WPF custom control with single/multi-select, custom columns, two-way MVVM binding
+- **Browse Dialog** — Real-time search/filter, keyboard navigation, selection persistence, item counter
+- **Pluggable Storage** — Switch between File (JSON/XML/CSV) and Database (SQL Server/SQLite/PostgreSQL/MySQL) via `appsettings.json`
+- **Themes** — Blue, Emerald, GruvboxDark, AyuDark theme assemblies
+- **MVVM** — Pure MVVM with attached behaviors, no UI logic in code-behind
+- **176 unit tests** covering all business logic
 
-### Browse Dialog
-- **Modern Design** - Clean, professional interface with Material Design-inspired colors
-- **MVVM Architecture** - Pure MVVM implementation using WPF Attached Behaviors
-- **Vector Search Icon** - Clean magnifying glass icon using SVG path for crisp rendering at any size
-- **Search & Filter** - Real-time search across all item properties
-- **Clear Filter Button** - Appears when search text is entered, clears with one click
-- **Flexible Column Display** - Auto-generated or custom column definitions
-- **Column Formatting** - Support for currency, date, and custom string formats
-- **Column Alignment** - Configure horizontal alignment (Left, Right, Center)
-- **Selection Highlighting** - Bold text and blue background for selected items
-- **Selection Persistence** - Previously selected item is automatically highlighted and scrolled into view
-- **Row Hover Effects** - Visual feedback on mouse over
-- **Item Counter** - Displays total filtered items count
-- **Responsive Design** - Resizable dialog with proper scrolling
-- **Keyboard Navigation** - Type to search, Enter to select, Escape to clear/cancel
+## Documentation
 
-### Error Handling
-- **File Not Found** - Gracefully handles missing Products.json file
-- **Empty File** - Handles empty or whitespace-only JSON files
-- **Invalid JSON** - Catches and handles JSON deserialization errors
-- **IO Errors** - Handles file access and permission issues
-- **Null Collections** - Validates data before opening dialogs with user-friendly messages
+| Document | Description |
+|----------|-------------|
+| [ARCHITECTURE.md](ARCHITECTURE.md) | Solution structure, project dependency graph, design patterns, and technical decisions |
+| [SETUP_GUIDE.md](SETUP_GUIDE.md) | Prerequisites, build/run instructions, configuration, and database setup |
+| [README_USER_SHORT.md](README_USER_SHORT.md) | End-user guide: features, DataBrowserBox usage, keyboard shortcuts |
+
+## Quick Start
+
+```bash
+# Build
+dotnet build TelAvivMuni-Exercise.sln
+
+# Run
+dotnet run --project TelAvivMuni-Exercise/TelAvivMuni-Exercise.csproj
+
+# Test
+dotnet test TelAvivMuni-Exercise.Tests/TelAvivMuni-Exercise.Tests.csproj
+```
+
+See [SETUP_GUIDE.md](SETUP_GUIDE.md) for full setup instructions including database configuration.
 
 ## Technology Stack
 
 - **Framework:** .NET 8.0 (WPF)
 - **Language:** C# 12
-- **UI Pattern:** MVVM (Model-View-ViewModel)
-- **Libraries:**
-  - CommunityToolkit.Mvvm 8.4.0 - For MVVM infrastructure (Core, Presentation)
-  - Microsoft.EntityFrameworkCore 8.0.12 - ORM for database access (Infrastructure, Core)
-  - Microsoft.EntityFrameworkCore.SqlServer 8.0.12 - SQL Server provider
-  - Microsoft.EntityFrameworkCore.Sqlite 8.0.12 - SQLite provider
-  - Npgsql.EntityFrameworkCore.PostgreSQL 8.0.11 - PostgreSQL provider
-  - Pomelo.EntityFrameworkCore.MySql 8.0.2 - MySQL provider
-  - Microsoft.Extensions.DependencyInjection 10.0.2 - IoC container (WPF)
-  - Microsoft.Extensions.DependencyInjection.Abstractions 10.0.2 - DI abstractions (WPF, Presentation)
-  - Microsoft.Extensions.Hosting 10.0.2 - Host builder for DI setup (WPF)
-  - Microsoft.Xaml.Behaviors.Wpf 1.1.135 - Attached behaviors (Controls)
-  - System.Text.Json - For JSON serialization
-  - xUnit 2.7.0 - For unit testing
-  - xunit.runner.visualstudio 2.5.7 - Test runner for Visual Studio
-  - Microsoft.NET.Test.Sdk 17.9.0 - Test platform
-  - Microsoft.EntityFrameworkCore.InMemory 8.0.12 - For database testing
-  - Moq 4.20.70 - For mocking in tests
-  - coverlet.collector 6.0.1 - For code coverage
+- **UI Pattern:** MVVM with CommunityToolkit.Mvvm 8.4.0
+- **ORM:** Entity Framework Core 8.0 (SQL Server, SQLite, PostgreSQL, MySQL)
+- **DI:** Microsoft.Extensions.Hosting 10.0.2
+- **Testing:** xUnit 2.7.0, Moq 4.20.70, coverlet
 
 ## Solution Structure
 
-The solution is organized into 23 projects to separate concerns and promote reusability:
-
-### TelAvivMuni-Exercise.Infrastructure
-Low-level data persistence abstractions and implementations:
-- **Data:**
-  - `IDataStore<T>` - Data persistence abstraction
-  - `FileDataStore<T>` - File-based data store with thread-safe async operations
-  - `DbDataStore<TEntity, TContext>` - SQL Server database data store using Entity Framework Core
-- **Models:**
-  - `IEntity` - Base entity interface with Id property
-- **Patterns:**
-  - `IDeferredInitialization` - View-First initialization interface
-- **Serializers:**
-  - `ISerializer<T>` - Serialization abstraction
-  - `JsonSerializer<T>` - JSON serialization using System.Text.Json
-
-### TelAvivMuni-Exercise.Domain
-Domain models shared across all projects:
-- **Models:**
-  - `Product` - Product data model implementing IEntity
-  - `BrowserColumn` - Column configuration for data browser
-  - `OperationResult` - Operation result with success/failure states
-
-### TelAvivMuni-Exercise.Core.Contracts
-Shared contracts and interfaces:
-- **Config:**
-  - `IColumnConfiguration` - Column configuration interface
-- **Patterns:**
-  - `IRepository<T>` - Generic repository interface
-  - `IUnitOfWork` - Unit of Work interface
-- **Services:**
-  - `IDialogService` - Dialog service interface
-- **ViewModels:**
-  - `IMultiSelectViewModel` - Multi-select state contract (`AllowMultipleSelection` + `SelectedItems`) consumed by `DataBrowserDialog` code-behind without creating a circular project reference
-
-### TelAvivMuni-Exercise.Core
-Application-specific business logic:
-- **Data:**
-  - `AppDbContext` - Entity Framework Core DbContext for SQL Server
-- **Patterns:**
-  - `ProductRepository` - Product-specific repository implementation
-  - `UnitOfWork` - Unit of Work coordination pattern
-- `AppDbContextRegistrar` - Registers `AppDbContext` into DI; discovered at runtime via assembly scanning
-- `CoreAssembly` - Provides a reference to the Core assembly for runtime discovery without hardcoding its name
-
-### TelAvivMuni-Exercise.Controls
-Reusable WPF controls and attached behaviors:
-- **Controls:**
-  - `DataBrowserBox` - Custom reusable control for item selection
-  - `DataBrowserDialog` - Browse dialog UI
-- **Behaviors:**
-  - `AutoFocusSearchBehavior` - Auto-focus on typing
-  - `DataGridEnterBehavior` - Handle Enter key in DataGrid
-  - `DataGridScrollIntoViewBehavior` - Scroll to selected item
-  - `DialogCloseBehavior` - MVVM-friendly dialog closing
-  - `EscapeClearBehavior` - Clear text on Escape key
-- **Infrastructure:**
-  - `AssemblyInfo.cs` - `[XmlnsDefinition]` mapping `http://telaviv-muni-exe/controls` to Controls and Controls.Behaviors namespaces
-
-### TelAvivMuni-Exercise.Presentation
-ViewModels, services, and presentation infrastructure:
-- **Views:**
-  - `MainWindow.xaml(.cs)` - Main application window
-- **ViewModels:**
-  - `MainWindowViewModel` - Main window view model
-  - `DataBrowserDialogViewModel` - Dialog view model
-- **Services:**
-  - `DialogService` - Dialog service implementation (WPF-dependent)
-- **Infrastructure:**
-  - `ViewModelLocator` - DI-based ViewModel resolution for XAML
-  - `ICommand.Extension` - Command extension methods (WPF/MVVM-dependent)
-  - `AssemblyInfo.cs` - `[XmlnsDefinition]` mapping `http://telaviv-muni-exe/presentation` to all Presentation namespaces
-
-### TelAvivMuni-Exercise.Themes
-Base theme resources shared across all theme variants:
-- **Themes:**
-  - `Shared.xaml` - Neutral brush defaults, `LoadingOverlayBrush` fallback (used by `Generic.xaml`) and shared vector icons
-
-### TelAvivMuni-Exercise.Themes.Blue
-Blue theme variant:
-- **Themes:**
-  - `Blue.xaml` - Theme entry point (aggregator merging Shared + Blue.Styles)
-  - `Blue.Colors.xaml` - Blue color palette (brush definitions)
-  - `Blue.Styles.xaml` - Blue-specific control styles (buttons, DataGrid, ClearButton)
-
-### TelAvivMuni-Exercise.Themes.Emerald
-Emerald theme variant:
-- **Themes:**
-  - `Emerald.xaml` - Theme entry point (aggregator merging Shared + Emerald.Styles)
-  - `Emerald.Colors.xaml` - Emerald color palette (brush definitions)
-  - `Emerald.Styles.xaml` - Emerald-specific control styles (buttons, DataGrid, ClearButton)
-
-### TelAvivMuni-Exercise.Themes.Zed.GruvboxDark
-Gruvbox Dark theme variant:
-- **Themes:**
-  - `GruvboxDark.xaml` - Theme entry point (aggregator merging Shared + GruvboxDark.Styles)
-  - `GruvboxDark.Colors.xaml` - Gruvbox Dark color palette (brush definitions)
-  - `GruvboxDark.Styles.xaml` - GruvboxDark-specific control styles (buttons, DataGrid, DataBrowserBox override)
-
-### TelAvivMuni-Exercise.Themes.Zed.AyuDark
-Ayu Dark theme variant (Zed editor built-in palette):
-- **Themes:**
-  - `AyuDark.xaml` - Theme entry point (aggregator merging Shared + AyuDark.Styles)
-  - `AyuDark.Colors.xaml` - Ayu Dark color palette mapped from Zed's `ayu.json` (brush definitions)
-  - `AyuDark.Styles.xaml` - AyuDark-specific control styles (buttons, DataGrid, DataBrowserBox override)
-
-### TelAvivMuni-Exercise (Main WPF Application)
-Pure composition root — DI wiring and application entry point:
-- **Data:** - Sample product data (Products.json, Product.xml, Product.csv), SQL scripts
-- **Configuration:** - appsettings.json, appsettings.Development.json
-- `App.xaml(.cs)` - Application entry point with DI registration
-
-### TelAvivMuni-Exercise.Tests
-Unit tests for all projects
-
-### Project Dependencies
-```
-TelAvivMuni-Exercise.Infrastructure (no project dependencies)
-    └── Contains: IEntity, IDataStore, FileDataStore, DbDataStore, Serializers
-
-TelAvivMuni-Exercise.Domain
-    └── → TelAvivMuni-Exercise.Infrastructure
-    └── Contains: Product, BrowserColumn, OperationResult
-
-TelAvivMuni-Exercise.Core.Contracts
-    ├── → TelAvivMuni-Exercise.Domain
-    └── → TelAvivMuni-Exercise.Infrastructure
-    └── Contains: IRepository<T>, IUnitOfWork, IDialogService, IColumnConfiguration
-
-TelAvivMuni-Exercise.Core
-    ├── → TelAvivMuni-Exercise.Core.Contracts
-    ├── → TelAvivMuni-Exercise.Infrastructure
-    └── → TelAvivMuni-Exercise.Domain
-    └── Contains: AppDbContext, ProductRepository, UnitOfWork
-
-TelAvivMuni-Exercise.Themes (no project dependencies)
-    └── Contains: Shared.xaml (neutral brush defaults, shared icons)
-
-TelAvivMuni-Exercise.Themes.Blue
-    └── → TelAvivMuni-Exercise.Themes
-    └── Contains: Blue.xaml, Blue.Colors.xaml, Blue.Styles.xaml
-
-TelAvivMuni-Exercise.Themes.Emerald
-    └── → TelAvivMuni-Exercise.Themes
-    └── Contains: Emerald.xaml, Emerald.Colors.xaml, Emerald.Styles.xaml
-
-TelAvivMuni-Exercise.Themes.Zed.GruvboxDark
-    ├── → TelAvivMuni-Exercise.Themes
-    └── → TelAvivMuni-Exercise.Controls
-    └── Contains: GruvboxDark.xaml, GruvboxDark.Colors.xaml, GruvboxDark.Styles.xaml
-
-TelAvivMuni-Exercise.Themes.Zed.AyuDark
-    ├── → TelAvivMuni-Exercise.Themes
-    └── → TelAvivMuni-Exercise.Controls
-    └── Contains: AyuDark.xaml, AyuDark.Colors.xaml, AyuDark.Styles.xaml
-
-TelAvivMuni-Exercise.Controls
-    ├── → TelAvivMuni-Exercise.Core.Contracts
-    ├── → TelAvivMuni-Exercise.Infrastructure
-    ├── → TelAvivMuni-Exercise.Domain
-    └── → TelAvivMuni-Exercise.Themes
-    └── Contains: DataBrowserBox, DataBrowserDialog, Behaviors
-
-TelAvivMuni-Exercise.Presentation
-    ├── → TelAvivMuni-Exercise.Core.Contracts
-    ├── → TelAvivMuni-Exercise.Infrastructure
-    ├── → TelAvivMuni-Exercise.Controls
-    └── → TelAvivMuni-Exercise.Domain
-    └── Contains: ViewModels, DialogService, ViewModelLocator
-
-TelAvivMuni-Exercise (WPF)
-    ├── → TelAvivMuni-Exercise.Presentation
-    ├── → TelAvivMuni-Exercise.Controls
-    ├── → TelAvivMuni-Exercise.Core
-    ├── → TelAvivMuni-Exercise.Core.Contracts
-    ├── → TelAvivMuni-Exercise.Infrastructure
-    ├── → TelAvivMuni-Exercise.Domain
-    ├── → TelAvivMuni-Exercise.Themes.Blue
-    ├── → TelAvivMuni-Exercise.Themes.Emerald
-    ├── → TelAvivMuni-Exercise.Themes.Zed.GruvboxDark
-    └── → TelAvivMuni-Exercise.Themes.Zed.AyuDark
-
-TelAvivMuni-Exercise.Tests
-    ├── → TelAvivMuni-Exercise (WPF)
-    ├── → TelAvivMuni-Exercise.Presentation
-    ├── → TelAvivMuni-Exercise.Controls
-    ├── → TelAvivMuni-Exercise.Core
-    ├── → TelAvivMuni-Exercise.Core.Contracts
-    ├── → TelAvivMuni-Exercise.Infrastructure
-    └── → TelAvivMuni-Exercise.Domain
-```
-
-## Project Structure
+The solution has **23 projects** organized in layers:
 
 ```
 TelAvivMuni-Exercise.sln
 │
-├── TelAvivMuni-Exercise.Infrastructure/     # Data persistence layer (no project dependencies)
-│   ├── Data/
-│   │   ├── DbDataStore.cs                   # Database data store (EF Core)
-│   │   ├── FileDataStore.cs                 # File-based data store
-│   │   └── IDataStore.cs                    # Data persistence abstraction
-│   ├── Models/
-│   │   └── IEntity.cs                       # Base entity interface
-│   ├── Patterns/
-│   │   └── IDeferredInitialization.cs       # View-First initialization interface
-│   └── Serializers/
-│       ├── ISerializer.cs                   # Serialization abstraction
-│       └── JsonSerializer.cs                # JSON serialization implementation
+├── [Persistence Layer]
+│   ├── TelAvivMuni-Exercise.Persistence/           # Core abstractions (IDataStore, IEntity, ISerializer)
+│   ├── TelAvivMuni-Exercise.Persistence.FileBase/  # File-based store (FileDataStore)
+│   ├── TelAvivMuni-Exercise.Persistence.FileBase.Json/   # JSON provider
+│   ├── TelAvivMuni-Exercise.Persistence.FileBase.Xml/    # XML provider
+│   ├── TelAvivMuni-Exercise.Persistence.FileBase.Csv/    # CSV provider
+│   ├── TelAvivMuni-Exercise.Persistence.Database/        # DB store (DbDataStore, EF Core)
+│   ├── TelAvivMuni-Exercise.Persistence.Database.SqlServer/  # SQL Server provider (plugin)
+│   ├── TelAvivMuni-Exercise.Persistence.Database.Sqlite/     # SQLite provider (plugin)
+│   ├── TelAvivMuni-Exercise.Persistence.Database.PostgreSQL/ # PostgreSQL provider (plugin)
+│   └── TelAvivMuni-Exercise.Persistence.Database.MySql/      # MySQL provider (plugin)
 │
-├── TelAvivMuni-Exercise.Domain/             # Domain models
-│   └── Models/
-│       ├── BrowserColumn.cs                 # Column configuration model
-│       ├── OperationResult.cs               # Operation result with error messages
-│       └── Product.cs                       # Product data model
+├── [Domain / Business Logic]
+│   ├── TelAvivMuni-Exercise.Infrastructure/        # IDeferredInitialization (view-first pattern)
+│   ├── TelAvivMuni-Exercise.Domain/                # Domain models (Product, BrowserColumn, OperationResult)
+│   ├── TelAvivMuni-Exercise.Core.Contracts/        # Shared interfaces (IRepository, IUnitOfWork, IDialogService)
+│   └── TelAvivMuni-Exercise.Core/                  # Business logic (AppDbContext, ProductRepository, UnitOfWork)
 │
-├── TelAvivMuni-Exercise.Core.Contracts/     # Shared contracts and interfaces
-│   ├── Config/
-│   │   └── IColumnConfiguration.cs          # Column configuration interface
-│   ├── Patterns/
-│   │   ├── IRepositoryT.cs                  # Generic repository interface
-│   │   └── IUnitOfWork.cs                   # Unit of Work interface
-│   ├── Services/
-│   │   └── IDialogService.cs                # Dialog service interface
-│   └── ViewModels/
-│       └── IMultiSelectViewModel.cs         # Multi-select state contract for dialog ViewModels
+├── [Presentation Layer]
+│   ├── TelAvivMuni-Exercise.Controls/              # DataBrowserBox, DataBrowserDialog, Behaviors
+│   └── TelAvivMuni-Exercise.Presentation/          # ViewModels, DialogService, ViewModelLocator, MainWindow
 │
-├── TelAvivMuni-Exercise.Core/               # Business logic
-│   ├── Data/
-│   │   └── AppDbContext.cs                  # EF Core DbContext for SQL Server
-│   ├── Patterns/
-│   │   ├── ProductRepository.cs             # Product-specific repository
-│   │   └── UnitOfWork.cs                    # Unit of Work implementation
-│   ├── AppDbContextRegistrar.cs             # Registers AppDbContext into DI (runtime-discovered)
-│   └── CoreAssembly.cs                      # Assembly reference helper for runtime discovery
+├── [Themes]
+│   ├── TelAvivMuni-Exercise.Themes/                # Shared base resources (Shared.xaml)
+│   ├── TelAvivMuni-Exercise.Themes.Blue/           # Blue theme
+│   ├── TelAvivMuni-Exercise.Themes.Emerald/        # Emerald theme
+│   ├── TelAvivMuni-Exercise.Themes.Zed.GruvboxDark/ # Gruvbox Dark theme
+│   └── TelAvivMuni-Exercise.Themes.Zed.AyuDark/   # Ayu Dark theme
 │
-├── TelAvivMuni-Exercise.Controls/           # Reusable WPF controls & behaviors
-│   ├── Behaviors/
-│   │   ├── AutoFocusSearchBehavior.cs       # Auto-focus on typing
-│   │   ├── DataGridEnterBehavior.cs         # Handle Enter key in DataGrid
-│   │   ├── DataGridScrollIntoViewBehavior.cs # Scroll to selected item
-│   │   ├── DialogCloseBehavior.cs           # MVVM-friendly dialog closing
-│   │   └── EscapeClearBehavior.cs           # Clear text on Escape key
-│   ├── Themes/
-│   │   └── Generic.xaml                     # Control templates (merges Shared.xaml, all StaticResource)
-│   ├── AssemblyInfo.cs                      # XmlnsDefinition for XAML namespace alias
-│   ├── DataBrowserBox.cs                    # Custom reusable control
-│   └── DataBrowserDialog.xaml(.cs)          # Browse dialog UI
-│
-├── TelAvivMuni-Exercise.Themes/             # Base theme resources (shared across variants)
-│   ├── AssemblyInfo.cs
-│   └── Themes/
-│       └── Shared.xaml                      # Neutral brush defaults & shared vector icons
-│
-├── TelAvivMuni-Exercise.Themes.Blue/        # Blue theme variant
-│   ├── AssemblyInfo.cs
-│   └── Themes/
-│       ├── Blue.xaml                        # Theme entry point (aggregator)
-│       ├── Blue.Colors.xaml                 # Blue color palette (brush definitions)
-│       └── Blue.Styles.xaml                 # Blue-specific control styles
-│
-├── TelAvivMuni-Exercise.Themes.Emerald/     # Emerald theme variant
-│   ├── AssemblyInfo.cs
-│   └── Themes/
-│       ├── Emerald.xaml                     # Theme entry point (aggregator)
-│       ├── Emerald.Colors.xaml              # Emerald color palette (brush definitions)
-│       └── Emerald.Styles.xaml              # Emerald-specific control styles
-│
-├── TelAvivMuni-Exercise.Themes.Zed.GruvboxDark/  # Gruvbox Dark theme variant
-│   └── Themes/
-│       ├── GruvboxDark.xaml                 # Theme entry point (aggregator)
-│       ├── GruvboxDark.Colors.xaml          # Gruvbox Dark color palette (brush definitions)
-│       └── GruvboxDark.Styles.xaml          # GruvboxDark-specific control styles + DataBrowserBox override
-│
-├── TelAvivMuni-Exercise.Themes.Zed.AyuDark/      # Ayu Dark theme variant (Zed editor palette)
-│   └── Themes/
-│       ├── AyuDark.xaml                     # Theme entry point (aggregator)
-│       ├── AyuDark.Colors.xaml              # Ayu Dark color palette from Zed ayu.json (brush definitions)
-│       └── AyuDark.Styles.xaml              # AyuDark-specific control styles + DataBrowserBox override
-│
-├── TelAvivMuni-Exercise.Presentation/       # ViewModels, views & presentation services
-│   ├── Services/
-│   │   └── DialogService.cs                 # Dialog service implementation
-│   ├── ViewModels/
-│   │   ├── DataBrowserDialogViewModel.cs    # Dialog view model
-│   │   └── MainWindowViewModel.cs           # Main window view model
-│   ├── Views/
-│   │   └── MainWindow.xaml(.cs)             # Main application window
-│   ├── AssemblyInfo.cs                      # XmlnsDefinition for XAML namespace alias
-│   ├── ICommand.Extension.cs                # ICommand extension methods
-│   └── ViewModelLocator.cs                  # DI-based ViewModel resolution
-│
-├── TelAvivMuni-Exercise/                    # Composition root (entry point & DI wiring)
-│   ├── Data/
-│   │   ├── CreateProductsDatabase.sql       # SQL Server database setup script
-│   │   ├── GenerateSqlScript.ps1            # PowerShell script to generate SQL
-│   │   ├── Products.json                    # Sample product data (JSON)
-│   │   ├── Product.xml                      # Sample product data (XML)
-│   │   └── Product.csv                      # Sample product data (CSV)
-│   ├── App.xaml(.cs)                        # Application entry point with DI
-│   ├── AssemblyInfo.cs
-│   ├── StorageOptions.cs                    # Pluggable storage configuration
-│   ├── StorageRegistrationExtensions.cs     # Runtime provider discovery & DI registration
-│   ├── appsettings.json                     # Default configuration
-│   └── appsettings.Development.json         # Development configuration
-│
-├── TelAvivMuni-Exercise.Tests/              # Unit test project
-│   ├── Core/
-│   │   ├── AppDbContextTests.cs
-│   │   └── CoreAssemblyTests.cs
-│   ├── Domain/
-│   │   ├── BrowserColumnTests.cs
-│   │   ├── IEntityTests.cs
-│   │   └── OperationResultTests.cs
-│   ├── Infrastructure/
-│   │   ├── DbDataStoreTests.cs
-│   │   ├── FileDataStoreTests.cs
-│   │   ├── JsonSerializerTests.cs
-│   │   ├── ProductRepositoryTests.cs
-│   │   └── UnitOfWorkTests.cs
-│   └── Presentation/
-│       ├── DataBrowserDialogViewModelTests.cs
-│       └── MainWindowViewModelTests.cs
-│
-├── coverlet.runsettings                     # Code coverage configuration
-└── Settings.XamlStyler                      # XAML Styler formatting rules (xstyler CLI config)
+├── TelAvivMuni-Exercise/                           # Composition root (DI wiring, entry point)
+└── TelAvivMuni-Exercise.Tests/                     # Unit tests (176 tests)
 ```
 
-## Configuration
-
-### Storage Provider
-
-The application supports pluggable storage providers configured via `appsettings.json`:
-
-```json
-{
-  "Storage": {
-    "Kind": "File",
-    "Provider": "Json"
-  }
-}
-```
-
-**Storage Options:**
-
-| Property | Description | Default |
-|----------|-------------|---------|
-| `Kind` | `"File"` or `"Database"` | `"File"` |
-| `Provider` | File: `"Json"`, `"Xml"`, `"Csv"` — Database: `"SqlServer"`, `"Sqlite"`, `"PostgreSQL"`, `"MySql"` | `"Json"` |
-| `ConnectionString` | Direct connection string (database only) | — |
-| `ConnectionStringName` | Named entry from `ConnectionStrings` section | — |
-| `FilePath` | Custom file path (file-based only) | `Data/Products.{ext}` |
-
-**Example — File-based (JSON, default):**
-```json
-{
-  "Storage": { "Kind": "File", "Provider": "Json" }
-}
-```
-
-**Example — SQL Server:**
-```json
-{
-  "Storage": {
-    "Kind": "Database",
-    "Provider": "SqlServer",
-    "ConnectionStringName": "DefaultConnection"
-  },
-  "ConnectionStrings": {
-    "DefaultConnection": "Server=localhost\\SQLEXPRESS;Database=TelAvivMuni;Integrated Security=true;TrustServerCertificate=True"
-  }
-}
-```
-
-**Configuration Files:**
-- `appsettings.json` - Default configuration for all environments
-- `appsettings.Development.json` - Development-specific overrides (optional)
-
-The application uses `Host.CreateDefaultBuilder()` which automatically loads configuration files based on the environment.
-
-**Note:** Never commit sensitive credentials (usernames/passwords) to source control. Use environment-specific configuration files or secure configuration providers for production deployments.
-
-## How to Use
-
-### 1. Using the DataBrowserBox Control
-
-#### Basic Usage (Auto-Generated Columns)
-
-```xaml
-<controls:DataBrowserBox
-    Height="30"
-    ItemsSource="{Binding Products}"
-    SelectedItem="{Binding SelectedProduct, Mode=TwoWay}"
-    DisplayMemberPath="Name"
-    DialogTitle="Select Product"
-    DialogService="{StaticResource DialogService}" />
-```
-
-#### Advanced Usage (Custom Columns)
-
-```xaml
-<controls:DataBrowserBox
-    Height="30"
-    ItemsSource="{Binding Products}"
-    SelectedItem="{Binding SelectedProduct, Mode=TwoWay}"
-    DisplayMemberPath="Name"
-    DialogTitle="Select Product"
-    DialogService="{StaticResource DialogService}">
-    <controls:DataBrowserBox.Columns>
-        <local:BrowserColumn DataField="Name" Header="שם מוצר" Width="200"/>
-        <local:BrowserColumn DataField="Price" Header="מחיר" Width="100" Format="C2" HorizontalAlignment="Right"/>
-        <local:BrowserColumn DataField="Category" Header="קטגוריה" Width="150"/>
-        <local:BrowserColumn DataField="Code" Header="קוד" Width="120"/>
-    </controls:DataBrowserBox.Columns>
-</controls:DataBrowserBox>
-```
-
-**Properties:**
-- `ItemsSource` - The collection of items to browse
-- `SelectedItem` - The currently selected item (two-way binding, single-select mode)
-- `SelectedItems` - The currently selected items collection (two-way binding, multi-select mode)
-- `AllowMultipleSelection` - Enables multi-item selection mode; bind `SelectedItems` instead of `SelectedItem` (default: `false`)
-- `DisplayMemberPath` - Property name to display in the control
-- `DialogTitle` - Title for the browse dialog
-- `DialogService` - Service for showing the dialog
-- `Columns` - Optional custom column definitions (if not specified, columns are auto-generated)
-
-**BrowserColumn Properties:**
-- `DataField` - The property name to bind to
-- `Header` - Column header text (supports Hebrew and other languages)
-- `Width` - Column width in pixels (optional)
-- `Format` - String format (e.g., "C2" for currency, "N0" for numbers)
-- `HorizontalAlignment` - Text alignment: "Left", "Right", or "Center"
-
-### 2. Setting Up Dialog Service
-
-In `App.xaml`:
-```xaml
-<Application xmlns:pres="http://telaviv-muni-exe/presentation">
-  <Application.Resources>
-    <pres:DialogService x:Key="DialogService" />
-    <pres:ViewModelLocator x:Key="Locator" />
-  </Application.Resources>
-</Application>
-```
-
-### 3. Data Format
-
-Products.json example:
-```json
-[
-  {
-    "Id": 1,
-    "Code": "LAP-001",
-    "Name": "Laptop Pro 15",
-    "Category": "Computers",
-    "Price": 1299.99
-  }
-]
-```
-
-## Architecture
-
-### Repository and Unit of Work Patterns
-
-The application uses the Repository and Unit of Work patterns for data management, providing:
-
-- **Abstraction** - Decouples business logic from data persistence
-- **Testability** - Easy to mock for unit testing
-- **Flexibility** - Can swap persistence strategies (file, database, etc.)
-
-#### Key Components
-
-**IRepository<TEntity>** - Generic repository interface:
-```csharp
-public interface IRepository<TEntity> where TEntity : class
-{
-    IEnumerable<TEntity> Entities { get; }
-    Task<TEntity[]> GetAllAsync();
-    Task<TEntity?> GetByIdAsync(int id);
-    Task<OperationResult> AddAsync(TEntity entity);
-    Task<OperationResult> UpdateAsync(TEntity entity);
-    Task<OperationResult> DeleteAsync(TEntity entity);
-}
-```
-
-**IUnitOfWork** - Coordinates repositories and manages transactions:
-```csharp
-public interface IUnitOfWork : IDisposable
-{
-    IRepository<Product> Products { get; }
-    Task<int> SaveChangesAsync();
-}
-```
-
-**OperationResult** - Consistent result type for CRUD operations:
-```csharp
-var result = await repository.AddAsync(product);
-if (!result.Success)
-{
-    Console.WriteLine(result.ErrorMessage); // "A product with Id 1 already exists."
-}
-```
-
-#### Layered Abstraction
-
-The persistence layer uses Strategy pattern for flexibility:
-
-```
-ProductRepository (Core)
-    └── IDataStore<Product> (Infrastructure)
-            ├── FileDataStore<Product>           # File-based (JSON)
-            │       └── ISerializer<Product>
-            │               └── JsonSerializer<Product>
-            │
-            └── DbDataStore<Product, AppDbContext>  # Database (SQL Server)
-                    └── IDbContextFactory<AppDbContext> (Core)
-```
-
-This allows:
-- Swapping file-based storage for database storage (just change DI registration)
-- Changing serialization format (JSON → XML) without changing repository
-- Testing with in-memory implementations
-
-## Key Features Implementation
-
-### Column Configuration
-The control supports two modes for column display:
-
-1. **Auto-Generated Columns** (Default)
-   - Automatically creates columns for all public properties
-   - Simple to use, no configuration needed
-   - Good for quick prototypes and simple scenarios
-
-2. **Custom Columns**
-   - Define exactly which columns to display and in what order
-   - Support for Hebrew headers and RTL languages
-   - Custom formatting (currency, numbers, dates)
-   - Custom column widths and alignment
-   - Only displays specified columns
-
-### Search Functionality
-- Searches across all object properties
-- Case-insensitive matching
-- Real-time filtering as you type
-- Clear button appears automatically when text is entered
-- Maintains selection after filtering (if visible)
-
-### Selection Behavior
-- **Initial Selection** - Previously selected item is highlighted when dialog opens
-- **Auto-Scroll** - Selected item is automatically scrolled into view
-- **Filter Persistence** - Selection remains when typing filter text (if item is visible)
-- **Clear Filter Persistence** - Selection is restored when clearing the filter
-- **Dialog Reopening** - Selection is maintained and highlighted when dialog reopens
-- **Visual Feedback** - Bold blue text on light blue background (#E3F2FD, #1976D2)
-
-### Visual States
-- **Watermark** - Gray italic text: "Click to select..." when no item is selected
-- **Selected Item** - Black bold text with item name displayed in control
-- **No Selection Label** - Gray "No selection" text (hidden but preserves space when item is selected)
-- **Grid Selection** - Blue background (#E3F2FD) with bold blue text (#1976D2)
-- **Row Hover** - Light gray background (#F5F5F5)
-
-### Button Styles
-- **OK Button** - Blue (#2196F3) with white text, darker on hover
-- **Cancel Button** - Light gray (#F5F5F5) with dark text, darker on hover
-- **Browse Button** - Matches Cancel button style
-- **Clear Button** - Circular, transparent, appears on hover when search text exists
-
-## Building and Running
-
-### Prerequisites
-- .NET 8.0 SDK or later
-- Visual Studio 2022 (or any IDE with .NET 8 support)
-
-### Build
-```bash
-dotnet build TelAvivMuni-Exercise.sln
-```
-
-### Run
-```bash
-dotnet run --project TelAvivMuni-Exercise/TelAvivMuni-Exercise.csproj
-```
-
-Or simply press F5 in Visual Studio.
-
-### Run Tests
-```bash
-dotnet test TelAvivMuni-Exercise.Tests/TelAvivMuni-Exercise.Tests.csproj
-```
-
-### Run Tests with Code Coverage
-```bash
-dotnet test --settings coverlet.runsettings --collect:"XPlat Code Coverage" --results-directory ./TestResults
-```
-
-Generate coverage report:
-```bash
-reportgenerator -reports:"TestResults/**/coverage.cobertura.xml" -targetdir:"coveragereport" -reporttypes:TextSummary
-```
-
-The test suite includes **176 unit tests** with **45.6% line coverage** and **39.2% branch coverage** across all assemblies (core testable code maintains near-100% coverage; lower overall figures reflect untested persistence provider registrars — CSV, XML, MySQL, PostgreSQL, SQLite, SqlServer — and the composition-root `StorageRegistrationExtensions` class):
-- Repository operations (CRUD, error handling)
-- Unit of Work coordination
-- ViewModel commands and state management
-- Data store and serialization (File and Database)
-- AppDbContext entity operations
-- DbDataStore CRUD operations
-- OperationResult success/failure patterns
-- BrowserColumn model properties
-- DataBrowserDialogViewModel search, filter, and selection logic
-- MainWindowViewModel CRUD commands and error handling
-
-## Design Decisions
-
-### MVVM Pattern with Attached Behaviors
-- **Pure MVVM Implementation** - No code-behind event handlers for UI logic
-- **Attached Behaviors** - Reusable, declarative UI behaviors defined in XAML
-- **Clean Separation** - View logic separated from business logic
-- **Testable** - Behaviors and ViewModels can be unit tested independently
-- **Reusable** - Behaviors can be applied to any WPF control across the application
-
-#### Implemented Behaviors:
-1. **AutoFocusSearchBehavior** - Automatically focuses search box when typing starts anywhere in the dialog
-2. **DataGridEnterBehavior** - Executes a command when Enter key is pressed in DataGrid
-3. **DataGridScrollIntoViewBehavior** - Scrolls DataGrid to show the selected item when selection changes
-4. **DialogCloseBehavior** - Closes window when ViewModel's DialogResult changes (MVVM-friendly)
-5. **EscapeClearBehavior** - Clears TextBox content when Escape key is pressed
-
-### Custom Control vs UserControl
-- Chose Custom Control for better reusability
-- Template-based approach for flexible styling
-- Dependency properties for WPF-style usage
-- Follows WPF best practices
-
-### Dialog Service
-- Abstraction layer for showing dialogs
-- Easier to test and mock
-- Centralized dialog logic
-- Supports dependency injection
-- Passes column configuration to dialog
-
-### Error Handling Strategy
-- Defensive programming approach
-- Always initialize collections to empty (never null)
-- User-friendly error messages
-- Silent fallback for missing data files
-
-### Selection Synchronization (View-First Pattern)
-- **View-First Initialization** - Dialog window is created and rendered first, then data is loaded
-- **Deferred Loading** - ViewModel stores pending items/selection until View is ready
-- **Loading Overlay** - Semi-transparent "Loading..." overlay displayed while data loads
-- **ContentRendered Event** - Triggers `Initialize()` method via XAML `CallMethodAction` (no code-behind)
-- **IDeferredInitialization Interface** - Contract for ViewModels supporting deferred initialization
-- **IColumnConfiguration Interface** - Contract for ViewModels providing custom column definitions
-- Two-way XAML binding between DataGrid.SelectedItem and ViewModel.SelectedItem
-- `DataGridScrollIntoViewBehavior` scrolls to selected item (MVVM-friendly)
-- Clean MVVM separation: View depends only on interfaces, not concrete ViewModel types
-
-### Keyboard Interaction (via Attached Behaviors)
-- **Type-to-Search** - Start typing anywhere to focus search box automatically
-- **Enter to Select** - Press Enter in DataGrid to select item and close dialog
-- **Escape to Clear** - Press Escape in search box to clear filter text
-- **Escape to Cancel** - Press Escape elsewhere to cancel and close dialog
-- **No Code-Behind** - All keyboard handling implemented via reusable attached behaviors
-
-## Recent Improvements
-
-### Multi-Select Support + Clear Button Fix (v8.3)
-- **`AllowMultipleSelection` property added** — `DataBrowserBox` now supports multi-item selection mode; set `AllowMultipleSelection=True` and bind `SelectedItems` (an `IList`) to receive the selected collection
-- **`SelectedItems` dependency property** — Two-way bindable `IList` DP with `FrameworkPropertyMetadataOptions.BindsTwoWayByDefault`; subscribes to `INotifyCollectionChanged` when the collection reference changes
-- **Clear button (×) fixed in multi-select mode** — `OnBrowseButtonClick` now explicitly calls `UpdateHasSelection()` and `UpdateDisplayText()` after in-place `SelectedItems.Clear()` + `Add()` mutations, mirroring the pattern already used by `OnClearButtonClick`; `UpdateHasSelection()` also sets `_clearButton.Visibility` directly as a belt-and-suspenders bypass for the WPF `ControlTemplate.Trigger` pipeline
-- **`DataBrowserDialog` multi-select DataGrid** — `SelectionMode=Extended` now correctly applied via a Style `<Setter>` (not a local attribute) so `AllowMultipleSelection` can override it through the `DataTrigger` without being shadowed by local-value precedence
-- **13 new unit tests** in `DataBrowserDialogViewModelTests` covering multi-select constructor, preselection, `OkCommand.CanExecute` with selection states, and filter interactions — **176 unit tests** total
-### Ayu Dark Theme (v8.2)
-- **`TelAvivMuni-Exercise.Themes.Zed.AyuDark` added** — New standalone theme assembly implementing the Zed editor built-in [Ayu Dark](https://github.com/zed-industries/zed/blob/main/assets/themes/ayu/ayu.json) palette, following the exact same three-file structure as `TelAvivMuni-Exercise.Themes.Zed.GruvboxDark`
-- **Exact Zed palette** — All 21 brush keys (`PrimaryBrush #5ac1fe`, `NeutralDarkBrush #313337`, `TextPrimaryBrush #bfbdb6`, `WhiteBrush #0d1016`, etc.) sourced directly from Zed's `assets/themes/ayu/ayu.json`
-- **DataBrowserBox dark theme override** — `AyuDark.Styles.xaml` provides an implicit `Style TargetType="controls:DataBrowserBox"` using `AyuDarkBrowseButtonStyle` and `AyuDarkDataBrowserTextBoxStyle` (internal keyed styles), consistent with the GruvboxDark approach
-- **Project reference to Controls** — `Themes.Zed.AyuDark` references `TelAvivMuni-Exercise.Controls` and `TelAvivMuni-Exercise.Themes` (no circular dependencies)
-- **App.xaml updated** — Comment block lists all four available theme URIs (Blue, Emerald, GruvboxDark, AyuDark) for easy theme switching
-- **All 163 unit tests** pass unchanged (pure XAML assembly, no C# logic to test)
-
-### GruvboxDark Theme + Full Dark UI Theming (v8.1)
-- **`TelAvivMuni-Exercise.Themes.Zed.GruvboxDark` added** — New standalone theme assembly implementing the [morhetz/gruvbox](https://github.com/morhetz/gruvbox) dark palette (`bg0 #282828`, `fg1 #ebdbb2`, green accent `#689d6a`)
-- **DataBrowserBox dark theme override** — `GruvboxDark.Styles.xaml` provides an implicit `Style TargetType="controls:DataBrowserBox"` that overrides `Generic.xaml`'s light defaults at app level, using only `StaticResource` (no `DynamicResource`)
-- **Project reference to Controls** — `Themes.Zed.GruvboxDark` references `TelAvivMuni-Exercise.Controls` (no circular dependency) to allow the `xmlns:controls` namespace in `GruvboxDark.Styles.xaml`
-- **`MainWindow.xaml` fully themed** — Background, all `TextBlock` foregrounds, and card `Border` brushes replaced with theme-aware `StaticResource` keys (`NeutralDarkBrush`, `TextPrimaryBrush`, `TextTertiaryBrush`, `WhiteBrush`, `BorderLightBrush`)
-- **`DataBrowserDialog.xaml` fully themed** — Background, search-box border, `TextBox` foreground/caret, and loading overlay replaced with `StaticResource` keys; hard-coded `"White"` and `"#80FFFFFF"` removed
-- **`LoadingOverlayBrush` added to all themes** — `Shared.xaml` defines the fallback (`#80FFFFFF`); `Blue.Colors.xaml` and `Emerald.Colors.xaml` override with the same light value; `GruvboxDark.Colors.xaml` overrides with semi-transparent dark (`#C0282828`)
-- **All 163 unit tests** pass unchanged
-
-### Theme Assembly Extraction (v8.0)
-- **Themes extracted to separate assemblies** — `TelAvivMuni-Exercise.Themes` (base), `.Themes.Blue`, and `.Themes.Emerald` are now standalone WPF class libraries, decoupling visual theming from the composition root
-- **`DynamicResource` eliminated** — All resource lookups replaced with `StaticResource` for faster XAML parsing and reduced runtime overhead (no runtime re-resolution)
-- **`Generic.xaml` self-contained** — The control template dictionary merges `Shared.xaml` via pack URI, providing its own brush scope; `BrowseButtonStyle` and `DataBrowserTextBoxStyle` moved from theme files into `Generic.xaml` where they architecturally belong (internal parts of `DataBrowserBox`)
-- **Pack URIs for cross-assembly references** — `App.xaml` loads the active theme via `pack://application:,,,/TelAvivMuni-Exercise.Themes.Blue;component/Themes/Blue.xaml`
-- **Theme entry-point aggregators** — Each theme's root XAML (`Blue.xaml`, `Emerald.xaml`) merges `Shared.xaml` + its own styles, providing a single include point for consumers
-- **163 unit tests** — all pass unchanged
-
-### Controls XmlnsDefinition (v7.3)
-- **`[assembly: XmlnsDefinition]`** added to `TelAvivMuni-Exercise.Controls/AssemblyInfo.cs`, mapping `http://telaviv-muni-exe/controls` to both `TelAvivMuni_Exercise.Controls` and `TelAvivMuni_Exercise.Controls.Behaviors` — mirrors the same convention already established in the Presentation assembly
-- **Consumer XAML simplified** — `MainWindow.xaml` replaces the verbose `clr-namespace:TelAvivMuni_Exercise.Controls;assembly=TelAvivMuni-Exercise.Controls` with `xmlns:controls="http://telaviv-muni-exe/controls"`
-- **Intra-assembly references unchanged** — `DataBrowserDialog.xaml` and `Generic.xaml` continue to use bare `clr-namespace:` (no `assembly=`), which is correct for references within the same assembly
-- **MC3074 fix** — `MainWindow.xaml` `xmlns:local` restored to `clr-namespace:TelAvivMuni_Exercise.Domain;assembly=TelAvivMuni-Exercise.Domain`; Domain stays `net8.0` (platform-neutral) so `XmlnsDefinitionAttribute` (WPF-only) cannot be applied to it — the full `clr-namespace:...;assembly=...` form is required here
-- **163 unit tests** — all pass unchanged
-
-### MainWindow Moved to Presentation (v7.2)
-- **`MainWindow.xaml(.cs)` relocated** to `TelAvivMuni-Exercise.Presentation/Views/` — the Presentation project now owns all view-layer files
-- **WinExe project is a pure composition root** — `TelAvivMuni-Exercise` contains only `App`, DI wiring, themes, and configuration; no Window types remain there
-- **`[assembly: XmlnsDefinition]`** added to `TelAvivMuni-Exercise.Presentation/AssemblyInfo.cs`, mapping the URI `http://telaviv-muni-exe/presentation` to all Presentation namespaces; `App.xaml` now uses a single `xmlns:pres` alias instead of separate `xmlns:services`/`xmlns:localInfra` declarations
-- **Programmatic startup** — `StartupUri` replaced by `new MainWindow().Show()` in `OnStartup`, the idiomatic WPF approach when the startup window lives in a referenced assembly
-- **163 unit tests** — all pass unchanged; `MainWindow` was already `[ExcludeFromCodeCoverage]`
-
-### Assembly Discovery Refactor (v7.1)
-- **Removed hardcoded assembly name** - `StorageRegistrationExtensions` no longer references the literal string `"TelAvivMuni-Exercise.Core.dll"` for `IDbContextRegistrar` discovery
-- **Added `CoreAssembly`** - A lightweight static helper in the Core project that exposes `Assembly.GetExecutingAssembly()`, ensuring the correct assembly is always resolved at runtime regardless of what calls it
-- **Shared `ScanAssembly` helper** - The type-scanning loop is now extracted and reused by both the glob-based and assembly-based overloads of `DiscoverRegistrars`
-- **163 unit tests** - Added `CoreAssemblyTests` to verify the assembly name and identity
-
-### Project Decomposition Refactor (v7.0)
-- **Extracted `TelAvivMuni-Exercise.Domain`** - Domain models (Product, BrowserColumn, OperationResult) now in a dedicated project
-- **Extracted `TelAvivMuni-Exercise.Controls`** - WPF controls and attached behaviors separated from the main WPF project
-- **Extracted `TelAvivMuni-Exercise.Presentation`** - ViewModels, DialogService, and ViewModelLocator in their own project
-- **Moved `IEntity` to Infrastructure** - Base entity interface lives with persistence abstractions
-- **Moved `AppDbContext` to Core** - DbContext consolidated with business logic patterns
-- **7 clean projects** - Infrastructure → Domain → Core.Contracts → Core → Controls/Presentation → WPF
-- **163 unit tests** - Test project references all projects for comprehensive coverage
-
-### Architectural Layering Refactor (v6.0)
-- **Core project no longer depends on EF Core** - Clean separation of business logic from infrastructure
-- **Eliminated circular dependencies** - Clear dependency direction
-- **Better layering** - Infrastructure owns persistence, Core owns business logic patterns
-
-### Database Support (v5.0)
-- **Entity Framework Core 8.0** - Added SQL Server database support
-- **DbDataStore<TEntity, TContext>** - Generic database data store implementing `IDataStore<T>`
-- **AppDbContext** - EF Core DbContext with Product entity configuration
-- **Pluggable persistence** - Switch between file and database storage via DI configuration
-- **163 unit tests** - Expanded test coverage including database operations
-- **InMemory testing** - Database tests use EF Core InMemory provider
-
-### Local Database Setup
-
-Follow these steps to run the SQL Server–backed version of the application locally.
-
-1. **Install SQL Server (or use a local container)**
-   - Install **SQL Server Developer** or **SQL Server Express** on your machine  
-     – or –  
-     run a local SQL Server container (for example, using the official `mcr.microsoft.com/mssql/server` image).
-   - Ensure you have a SQL client tool installed, such as **SQL Server Management Studio (SSMS)**, **Azure Data Studio**, or the `sqlcmd` CLI.
-
-2. **Generate and/or run the database script**
-   - Option A – **PowerShell script**  
-     Run `GenerateSqlScript.ps1` from a PowerShell prompt in the repository root (or the folder where the script resides):
-     ```powershell
-     pwsh ./GenerateSqlScript.ps1
-     ```
-     This will generate the SQL script needed to create the database and tables (if applicable).
-   - Option B – **SQL script**  
-     Open `CreateProductsDatabase.sql` in your SQL client and execute it against your local SQL Server instance.
-
-3. **Create the database and tables**
-   - Ensure that the script is executed against the intended server/instance (for example, `localhost` or `localhost,1433`).
-   - After running `CreateProductsDatabase.sql` (directly or via the PowerShell script), verify that:
-     - A database (for example, `ProductsDb`) has been created.
-     - The `Products` table (and any other required tables) exists and was created without errors.
-
-4. **Configure the connection string**
-   - Locate the application’s connection string configuration (for example, in `appsettings.json`, `App.config`, or `appsettings.Development.json`).
-   - Update the SQL Server connection string used by the application (for example, a connection named `ProductsConnection`) so that:
-     - `Server` (or `Data Source`) points to your local SQL Server instance, such as `localhost` or `localhost\\SQLEXPRESS`.
-     - `Database` (or `Initial Catalog`) matches the database name created by `CreateProductsDatabase.sql`.
-     - Authentication (Integrated Security or User ID/Password) matches how you connect to your local SQL Server.
-
-5. **Verify the setup**
-   - Start your local SQL Server instance and confirm the database is reachable using your SQL client.
-   - Run the WPF application.
-   - Navigate to the part of the UI that loads products. If the database is configured correctly, product data should load from SQL Server without errors.
-   - Optionally, add or edit a product in the application and confirm that the changes appear in the `Products` table when queried from your SQL client.
-### Test Coverage (v4.0)
-- **163 unit tests** - Comprehensive test coverage for all business logic
-- **41.4% line coverage** - Measured via coverlet with Cobertura reporting (core testable code at near-100%; lower overall figure reflects untested persistence provider registrars — CSV, XML, MySQL, PostgreSQL, SQLite, SqlServer — and composition-root classes)
-- **34.0% branch coverage** - Covers conditional logic paths
-- **Coverage exclusions** - WPF UI components (behaviors, controls, dialogs) are excluded using `[ExcludeFromCodeCoverage]` attribute
-- **Coverlet configuration** - `coverlet.runsettings` file for consistent coverage measurement
-
-### Repository and Unit of Work Patterns (v3.0)
-- **Added Repository pattern** - Abstracts data access with `IRepository<T>`
-- **Added Unit of Work pattern** - Coordinates repositories via `IUnitOfWork`
-- **Layered persistence** - `IDataStore<T>` and `ISerializer<T>` for flexibility
-- **OperationResult type** - Consistent error handling with descriptive messages
-- **Improved testability** - All dependencies are injectable and mockable
-
-### MVVM Refactoring (v2.0)
-- **Removed ~80 lines** of keyboard event handling code from code-behind
-- **Added 4 reusable attached behaviors** for declarative UI logic
-- **Improved maintainability** - Behaviors are independently testable and reusable
-- **Better separation of concerns** - View logic moved from code-behind to XAML
-- **Cleaner architecture** - True MVVM pattern with no UI logic in code-behind
-
-## Future Enhancements
-
-Potential improvements for production use:
-- Add virtualization for large datasets (currently loads all items)
-- Implement column sorting (click column headers to sort)
-- Add column resizing (drag column borders)
-- Add export functionality (CSV, Excel)
-- Custom column templates (images, buttons, checkboxes)
-- Additional behaviors (double-click to select, arrow key navigation)
-- Accessibility features (screen reader support, high contrast themes)
-- Full localization support (resources for all strings)
-- Column reordering (drag-and-drop columns)
-- Save/restore column configurations
-- Advanced filtering (dropdown filters per column)
+> Provider plugins (SqlServer, SQLite, PostgreSQL, MySQL, XML, CSV) are discovered at runtime via assembly scanning — drop a new provider DLL into the bin directory and update `appsettings.json`; no recompilation needed.
 
 ## License
 
@@ -891,7 +96,3 @@ This project is created for educational and interview purposes.
 ## Author
 
 Created as part of the Tel-Aviv Municipality interview process for Software Developer position.
-
-## Contact
-
-For questions or feedback about this project, please contact through the interview process.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ TelAvivMuni-Exercise.sln
 └── TelAvivMuni-Exercise.Tests/                     # Unit tests (176 tests)
 ```
 
-> Provider plugins (SqlServer, SQLite, PostgreSQL, MySQL, XML, CSV) are discovered at runtime via assembly scanning — drop a new provider DLL into the bin directory and update `appsettings.json`; no recompilation needed.
+> Provider plugins (SqlServer, SQLite, PostgreSQL, MySQL, Json, XML, CSV) are discovered at runtime via assembly scanning — drop a new provider DLL into the bin directory and update `appsettings.json`; no recompilation needed.
 
 ## License
 

--- a/README_USER_SHORT.md
+++ b/README_USER_SHORT.md
@@ -17,8 +17,8 @@ A drop-in WPF control that shows the currently selected item(s) alongside a brow
 
 ### Browse Dialog
 
-| Feature | Behaviour |
-|---------|-----------|
+| Feature | Behavior |
+|---------|----------|
 | Search | Type anywhere to filter rows in real time (case-insensitive, searches all columns) |
 | Clear filter | × button appears when search text is present; click to clear |
 | Item counter | Shows the number of currently visible items |

--- a/README_USER_SHORT.md
+++ b/README_USER_SHORT.md
@@ -1,0 +1,150 @@
+# User Guide
+
+## What This Application Does
+
+The application displays a product catalog and lets you browse, search, and select products using a reusable `DataBrowserBox` control. It supports single-item and multi-item selection, real-time filtering, and keyboard navigation.
+
+## Features
+
+### DataBrowserBox Control
+
+A drop-in WPF control that shows the currently selected item(s) alongside a browse button. Clicking the button opens a search dialog.
+
+- **Single-select mode** — select one item; the control displays its name
+- **Multi-select mode** — select multiple items; the control displays a count with a × clear button
+- **Watermark** — shows _"Click to select..."_ in italic when nothing is selected
+- **Custom columns** — configure which columns to show, with custom headers (including Hebrew/RTL), widths, number/currency formats, and alignment
+
+### Browse Dialog
+
+| Feature | Behaviour |
+|---------|-----------|
+| Search | Type anywhere to filter rows in real time (case-insensitive, searches all columns) |
+| Clear filter | × button appears when search text is present; click to clear |
+| Item counter | Shows the number of currently visible items |
+| Selection highlight | Selected row has a blue background and bold text |
+| Scroll to selection | Previously selected item is automatically scrolled into view when the dialog opens |
+| Resizable | Drag dialog borders to resize |
+
+### Keyboard Shortcuts
+
+| Key | Action |
+|-----|--------|
+| Any character | Focus search box and start filtering |
+| `Enter` (in grid) | Confirm selection and close |
+| `Escape` (in search box) | Clear filter text |
+| `Escape` (elsewhere) | Cancel and close dialog |
+
+### Themes
+
+The application ships with four themes selectable in `App.xaml`:
+- **Blue** (default light theme)
+- **Emerald** (green light theme)
+- **GruvboxDark** (dark theme, morhetz/gruvbox palette)
+- **AyuDark** (dark theme, Zed editor Ayu palette)
+
+## Using the DataBrowserBox Control
+
+### Basic Usage (auto-generated columns)
+
+```xaml
+<controls:DataBrowserBox
+    Height="30"
+    ItemsSource="{Binding Products}"
+    SelectedItem="{Binding SelectedProduct, Mode=TwoWay}"
+    DisplayMemberPath="Name"
+    DialogTitle="Select Product"
+    DialogService="{StaticResource DialogService}" />
+```
+
+### Multi-Select Mode
+
+```xaml
+<controls:DataBrowserBox
+    Height="30"
+    ItemsSource="{Binding Products}"
+    SelectedItems="{Binding SelectedProducts, Mode=TwoWay}"
+    AllowMultipleSelection="True"
+    DisplayMemberPath="Name"
+    DialogTitle="Select Products"
+    DialogService="{StaticResource DialogService}" />
+```
+
+### Custom Columns
+
+```xaml
+<controls:DataBrowserBox
+    Height="30"
+    ItemsSource="{Binding Products}"
+    SelectedItem="{Binding SelectedProduct, Mode=TwoWay}"
+    DisplayMemberPath="Name"
+    DialogTitle="Select Product"
+    DialogService="{StaticResource DialogService}">
+    <controls:DataBrowserBox.Columns>
+        <local:BrowserColumn DataField="Name"     Header="שם מוצר"  Width="200" />
+        <local:BrowserColumn DataField="Price"    Header="מחיר"     Width="100" Format="C2" HorizontalAlignment="Right" />
+        <local:BrowserColumn DataField="Category" Header="קטגוריה"  Width="150" />
+        <local:BrowserColumn DataField="Code"     Header="קוד"      Width="120" />
+    </controls:DataBrowserBox.Columns>
+</controls:DataBrowserBox>
+```
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `ItemsSource` | `IEnumerable` | Collection of items to browse |
+| `SelectedItem` | `object` | Currently selected item (single-select) |
+| `SelectedItems` | `IList` | Currently selected items (multi-select) |
+| `AllowMultipleSelection` | `bool` | Enable multi-item selection (default: `false`) |
+| `DisplayMemberPath` | `string` | Property name shown in the control after selection |
+| `DialogTitle` | `string` | Title bar text for the browse dialog |
+| `DialogService` | `IDialogService` | Service that creates and shows the dialog |
+| `Columns` | `IList<BrowserColumn>` | Custom column definitions (auto-generated if omitted) |
+
+### BrowserColumn Properties
+
+| Property | Description |
+|----------|-------------|
+| `DataField` | Property name to bind (e.g. `"Price"`) |
+| `Header` | Column header text (supports Hebrew and other languages) |
+| `Width` | Column width in pixels |
+| `Format` | String format, e.g. `"C2"` for currency, `"N0"` for integers, `"d"` for short date |
+| `HorizontalAlignment` | `"Left"`, `"Right"`, or `"Center"` |
+
+## Data Format
+
+The application reads product data from the configured storage provider. The default JSON file (`Data/Product.json`) uses this structure:
+
+```json
+[
+  {
+    "Id": 1,
+    "Code": "LAP-001",
+    "Name": "Laptop Pro 15",
+    "Category": "Computers",
+    "Price": 1299.99
+  }
+]
+```
+
+## Error Messages
+
+| Situation | What happens |
+|-----------|-------------|
+| Data file not found | Silent fallback — empty list is shown |
+| Invalid JSON / parse error | Message box describes the problem |
+| Empty collection on Browse click | Message box asks the user to load data first |
+| Database connection failure | Error message with connection details |
+
+## Switching Storage Providers
+
+Open `TelAvivMuni-Exercise/appsettings.json` and change the `Storage` section:
+
+```json
+{ "Storage": { "Kind": "File", "Provider": "Json" } }
+```
+
+Available values: `Kind` = `"File"` or `"Database"`; `Provider` = `"Json"`, `"Xml"`, `"Csv"`, `"SqlServer"`, `"Sqlite"`, `"PostgreSQL"`, `"MySql"`.
+
+See [SETUP_GUIDE.md](SETUP_GUIDE.md) for full configuration details.

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -35,9 +35,7 @@ dotnet test --settings coverlet.runsettings --collect:"XPlat Code Coverage" --re
 Generate a human-readable coverage report (requires `reportgenerator` tool):
 
 ```bash
-reportgenerator -reports:"TestResults/**/coverage.cobertura.xml" \
-                -targetdir:"coveragereport" \
-                -reporttypes:TextSummary
+reportgenerator -reports:"TestResults/**/coverage.cobertura.xml" -targetdir:"coveragereport" -reporttypes:TextSummary
 ```
 
 Current coverage: **176 unit tests**, **45.6% line coverage**, **39.2% branch coverage** across all assemblies. Core testable code (repositories, ViewModels, domain models, data stores) maintains near-100% coverage; lower overall figures reflect untested provider registrar classes (CSV, XML, MySQL, PostgreSQL, SQLite, SqlServer) and the composition-root `StorageRegistrationExtensions`.

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -1,0 +1,209 @@
+# Setup Guide
+
+## Prerequisites
+
+- [.NET 8.0 SDK](https://dotnet.microsoft.com/download/dotnet/8.0) or later
+- Visual Studio 2022 (or any IDE with .NET 8 WPF support, e.g. Rider)
+- *(Database mode only)* An accessible instance of SQL Server, SQLite, PostgreSQL, or MySQL
+
+## Build
+
+```bash
+dotnet build TelAvivMuni-Exercise.sln
+```
+
+## Run
+
+```bash
+dotnet run --project TelAvivMuni-Exercise/TelAvivMuni-Exercise.csproj
+```
+
+Or press **F5** in Visual Studio.
+
+## Run Tests
+
+```bash
+dotnet test TelAvivMuni-Exercise.Tests/TelAvivMuni-Exercise.Tests.csproj
+```
+
+### Run Tests with Code Coverage
+
+```bash
+dotnet test --settings coverlet.runsettings --collect:"XPlat Code Coverage" --results-directory ./TestResults
+```
+
+Generate a human-readable coverage report (requires `reportgenerator` tool):
+
+```bash
+reportgenerator -reports:"TestResults/**/coverage.cobertura.xml" \
+                -targetdir:"coveragereport" \
+                -reporttypes:TextSummary
+```
+
+Current coverage: **176 unit tests**, **45.6% line coverage**, **39.2% branch coverage** across all assemblies. Core testable code (repositories, ViewModels, domain models, data stores) maintains near-100% coverage; lower overall figures reflect untested provider registrar classes (CSV, XML, MySQL, PostgreSQL, SQLite, SqlServer) and the composition-root `StorageRegistrationExtensions`.
+
+## Storage Configuration
+
+The application reads `TelAvivMuni-Exercise/appsettings.json` (and optionally `appsettings.Development.json`) on startup.
+
+### Storage options
+
+| Property | Description | Default |
+|----------|-------------|---------|
+| `Kind` | `"File"` or `"Database"` | `"File"` |
+| `Provider` | File: `"Json"`, `"Xml"`, `"Csv"` — Database: `"SqlServer"`, `"Sqlite"`, `"PostgreSQL"`, `"MySql"` | `"Json"` |
+| `ConnectionString` | Inline connection string (database only) | — |
+| `ConnectionStringName` | Key from the `ConnectionStrings` section | — |
+| `FilePath` | Custom file path (file-based only) | `Data/Product.{ext}` |
+
+### Example — File-based JSON (simplest)
+
+```json
+{
+  "Storage": { "Kind": "File", "Provider": "Json" }
+}
+```
+
+### Example — File-based XML
+
+```json
+{
+  "Storage": { "Kind": "File", "Provider": "Xml" }
+}
+```
+
+### Example — SQL Server
+
+```json
+{
+  "Storage": {
+    "Kind": "Database",
+    "Provider": "SqlServer",
+    "ConnectionStringName": "DefaultConnection"
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=localhost\\SQLEXPRESS;Database=TelAvivMuni;Integrated Security=true;TrustServerCertificate=True"
+  }
+}
+```
+
+### Example — SQLite
+
+```json
+{
+  "Storage": {
+    "Kind": "Database",
+    "Provider": "Sqlite",
+    "ConnectionString": "Data Source=TelAvivMuni.db"
+  }
+}
+```
+
+### Example — PostgreSQL
+
+```json
+{
+  "Storage": {
+    "Kind": "Database",
+    "Provider": "PostgreSQL",
+    "ConnectionString": "Host=localhost;Database=TelAvivMuni;Username=postgres;Password=secret"
+  }
+}
+```
+
+> **Security note:** Never commit credentials to source control. Use `appsettings.Development.json` (git-ignored) or environment variables for secrets.
+
+## Local SQL Server Setup
+
+Follow these steps to run the SQL Server-backed version locally.
+
+### 1. Install SQL Server
+
+Install **SQL Server Developer** or **SQL Server Express**, or run a local container:
+
+```bash
+docker run -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourPassword123!" \
+  -p 1433:1433 -d mcr.microsoft.com/mssql/server:2022-latest
+```
+
+Have a SQL client ready: **SSMS**, **Azure Data Studio**, or `sqlcmd`.
+
+### 2. Create the database and tables
+
+**Option A — PowerShell script:**
+
+```powershell
+pwsh ./Data/GenerateSqlScript.ps1
+```
+
+**Option B — Run the SQL script directly:**
+
+Open `Data/CreateProductsDatabase.sql` in your SQL client and execute it against your SQL Server instance.
+
+After running the script, verify that:
+- The database (e.g. `TelAvivMuni`) was created.
+- The `Products` table exists.
+
+### 3. Update the connection string
+
+Edit `TelAvivMuni-Exercise/appsettings.json`:
+
+```json
+{
+  "Storage": {
+    "Kind": "Database",
+    "Provider": "SqlServer",
+    "ConnectionStringName": "DefaultConnection"
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=localhost\\SQLEXPRESS;Database=TelAvivMuni;Integrated Security=true;TrustServerCertificate=True"
+  }
+}
+```
+
+Adjust `Server`, `Database`, and authentication to match your instance.
+
+### 4. Verify
+
+Start the application and navigate to the product browser. Products should load from SQL Server. Add a product in the UI and confirm the row appears in the `Products` table when queried from your SQL client.
+
+## Switching the Active Theme
+
+Open `TelAvivMuni-Exercise/App.xaml` and replace the merged dictionary URI with the desired theme:
+
+```xml
+<!-- Blue (default light) -->
+<ResourceDictionary Source="pack://application:,,,/TelAvivMuni-Exercise.Themes.Blue;component/Themes/Blue.xaml" />
+
+<!-- Emerald (green light) -->
+<ResourceDictionary Source="pack://application:,,,/TelAvivMuni-Exercise.Themes.Emerald;component/Themes/Emerald.xaml" />
+
+<!-- Gruvbox Dark -->
+<ResourceDictionary Source="pack://application:,,,/TelAvivMuni-Exercise.Themes.Zed.GruvboxDark;component/Themes/GruvboxDark.xaml" />
+
+<!-- Ayu Dark -->
+<ResourceDictionary Source="pack://application:,,,/TelAvivMuni-Exercise.Themes.Zed.AyuDark;component/Themes/AyuDark.xaml" />
+```
+
+## Data Files
+
+Sample product data lives in the `Data/` folder at solution root:
+
+| File | Format |
+|------|--------|
+| `Data/Product.json` | JSON |
+| `Data/Product.xml` | XML |
+| `Data/Product.csv` | CSV |
+| `Data/CreateProductsDatabase.sql` | SQL Server DDL + seed data |
+| `Data/GenerateSqlScript.ps1` | PowerShell helper to generate the SQL script |
+
+The WPF project copies all three file formats to its output `Data/` folder at build time. The active provider reads from `Data/Product.{ext}` by default; override with the `FilePath` setting.
+
+## Adding a New Provider (Plugin Architecture)
+
+Provider assemblies are discovered at runtime — no changes to the composition root are needed:
+
+1. Create a class library implementing `IFileProviderRegistrar` (file) or `IDbProviderRegistrar` (database).
+2. Build and copy the DLL to the application's bin directory.
+3. Update `appsettings.json` to reference the new `Provider` name.
+4. Restart the application.


### PR DESCRIPTION
- README.md: updated to reflect current Persistence layer structure (split into Persistence, FileBase, Database + provider plugins); trimmed to an overview entry-point with links to the three new docs
- ARCHITECTURE.md: solution structure, full project dependency graph, persistence strategy pattern diagram, plugin discovery, MVVM behaviors, view-first initialization, theme architecture, key design decisions, and version history (moved from README)
- SETUP_GUIDE.md: prerequisites, build/run/test commands, storage configuration table with examples for every provider, local SQL Server setup steps, theme switching, data files reference, and plugin extension guide (moved from README)
- README_USER_SHORT.md: end-user guide covering DataBrowserBox usage, keyboard shortcuts, themes, properties table, BrowserColumn reference, data format, error messages, and quick storage-switching instructions (moved from README)